### PR TITLE
fix(soap_api): WebServiceCall decorator was silently bypassed (upstream #45)

### DIFF
--- a/netsuite/soap_api/decorators.py
+++ b/netsuite/soap_api/decorators.py
@@ -1,3 +1,4 @@
+import inspect
 from functools import wraps
 from typing import Any, Callable, Optional
 
@@ -6,6 +7,17 @@ from . import zeep
 from .exceptions import NetsuiteResponseError
 
 __all__ = ("WebServiceCall",)
+
+
+def _is_soap_response(response: Any) -> bool:
+    # SOAP responses returned by zeep are instances of `CompoundValue`
+    # (dynamically generated subclasses produced from the WSDL schema).
+    # The previous implementation checked `isinstance(response,
+    # zeep.xsd.ComplexType)` — but `ComplexType` is the *schema* definition
+    # class, not the runtime value class, so the check was always False and
+    # the decorator silently returned the raw response without status
+    # validation or extraction. See jacobsvante/netsuite#45.
+    return isinstance(response, zeep.xsd.CompoundValue)
 
 
 def WebServiceCall(
@@ -32,9 +44,17 @@ def WebServiceCall(
 
     def decorator(fn):
         @wraps(fn)
-        def wrapper(self, *args, **kw):
+        async def async_wrapper(self, *args, **kw):
+            response = await fn(self, *args, **kw)
+            return _process_response(response)
+
+        @wraps(fn)
+        def sync_wrapper(self, *args, **kw):
             response = fn(self, *args, **kw)
-            if not isinstance(response, zeep.xsd.ComplexType):
+            return _process_response(response)
+
+        def _process_response(response):
+            if not _is_soap_response(response):
                 return response
 
             if path is not None:
@@ -68,6 +88,8 @@ def WebServiceCall(
 
             return response
 
-        return wrapper
+        if inspect.iscoroutinefunction(fn):
+            return async_wrapper
+        return sync_wrapper
 
     return decorator

--- a/tests/test_soap_api_decorators.py
+++ b/tests/test_soap_api_decorators.py
@@ -1,0 +1,124 @@
+"""Tests for the `WebServiceCall` decorator.
+
+Regression tests for jacobsvante/netsuite#45 — the decorator previously
+checked `isinstance(response, zeep.xsd.ComplexType)`, which is the schema
+definition class. Real SOAP responses are `zeep.xsd.CompoundValue` instances,
+so the check was always False and status validation / extraction were
+silently skipped. The decorator was also a synchronous wrapper around async
+SOAP methods, so even with the right isinstance check it would have received
+a coroutine instead of a response.
+"""
+
+import pytest
+
+from netsuite.soap_api.exceptions import NetsuiteResponseError
+from netsuite.soap_api.zeep import ZEEP_INSTALLED
+
+pytestmark = pytest.mark.skipif(not ZEEP_INSTALLED, reason="Requires zeep")
+
+if ZEEP_INSTALLED:
+    from zeep.xsd.valueobjects import CompoundValue
+
+    from netsuite.soap_api.decorators import WebServiceCall
+
+
+class _FakeResponse(CompoundValue):
+    """A minimal CompoundValue-shaped object usable as both attribute container and mapping."""
+
+    def __init__(self, **attrs):
+        # Bypass CompoundValue.__init__ which expects an XSD type
+        object.__setattr__(self, "_attrs", attrs)
+
+    def __getattr__(self, name):
+        attrs = object.__getattribute__(self, "_attrs")
+        if name in attrs:
+            return attrs[name]
+        raise AttributeError(name)
+
+    def __getitem__(self, key):
+        return object.__getattribute__(self, "_attrs")[key]
+
+    def __iter__(self):
+        return iter(object.__getattribute__(self, "_attrs").values())
+
+
+def _ok_status():
+    return {"isSuccess": True, "statusDetail": []}
+
+
+def _err_status(detail="boom"):
+    return {"isSuccess": False, "statusDetail": detail}
+
+
+@pytest.mark.asyncio
+async def test_async_decorator_unwraps_path_and_extracts():
+    """Decorator must descend `path` and apply `extract` for async SOAP methods."""
+
+    inner = _FakeResponse(record={"id": 42}, status=_ok_status())
+    outer = _FakeResponse(body=_FakeResponse(readResponse=inner))
+
+    @WebServiceCall(
+        "body.readResponse",
+        extract=lambda resp: resp["record"],
+    )
+    async def fake_get(self):
+        return outer
+
+    result = await fake_get(object())
+    assert result == {"id": 42}
+
+
+@pytest.mark.asyncio
+async def test_async_decorator_raises_on_failed_status():
+    inner = _FakeResponse(record=None, status=_err_status("nope"))
+    outer = _FakeResponse(body=_FakeResponse(readResponse=inner))
+
+    @WebServiceCall("body.readResponse")
+    async def fake_get(self):
+        return outer
+
+    with pytest.raises(NetsuiteResponseError):
+        await fake_get(object())
+
+
+@pytest.mark.asyncio
+async def test_async_decorator_passes_through_non_soap_values():
+    """If the wrapped function returns a non-CompoundValue (e.g. early-out []),
+    the decorator should return it untouched without trying to walk `path`."""
+
+    @WebServiceCall("body.readResponseList.readResponse")
+    async def fake_getList(self):
+        return []
+
+    assert await fake_getList(object()) == []
+
+
+@pytest.mark.asyncio
+async def test_async_decorator_returns_default_when_path_missing():
+    outer = _FakeResponse(body=_FakeResponse())  # no `getItemAvailabilityResult`
+
+    @WebServiceCall(
+        "body.getItemAvailabilityResult",
+        extract=lambda resp: resp["itemAvailabilityList"]["itemAvailability"],
+        default=[],
+    )
+    async def fake_getItemAvailability(self):
+        return outer
+
+    assert await fake_getItemAvailability(object()) == []
+
+
+def test_sync_decorator_still_works():
+    """Sync functions decorated with WebServiceCall should also process responses."""
+
+    inner = _FakeResponse(record={"id": 7}, status=_ok_status())
+    outer = _FakeResponse(body=_FakeResponse(readResponse=inner))
+
+    @WebServiceCall(
+        "body.readResponse",
+        extract=lambda resp: resp["record"],
+    )
+    def fake_get_sync(self):
+        return outer
+
+    assert fake_get_sync(object()) == {"id": 7}


### PR DESCRIPTION
## Summary

Fixes the bug reported in [jacobsvante/netsuite#45](https://github.com/jacobsvante/netsuite/issues/45): the `WebServiceCall` decorator was a no-op on every SOAP call.

Two compounding problems:

1. **Wrong isinstance target** — `isinstance(response, zeep.xsd.ComplexType)` checks against the *schema-definition* class. Real SOAP responses are `zeep.xsd.CompoundValue` instances, so the check was always False and the decorator returned the raw response without status validation or `extract`.
2. **Sync wrapper around async methods** — even if the isinstance check were correct, every method in `NetSuiteSoapApi` (`get`, `getList`, `add`, `search`, …) is `async def`, so `fn(self, …)` returned a coroutine, not a response. The decorator was checking `isinstance(coroutine, …)`.

This PR:

- Detects coroutine functions at decoration time and awaits inside an async wrapper; falls back to the original sync wrapper for any non-async callers.
- Switches the runtime check to `zeep.xsd.CompoundValue`.
- Adds regression tests in `tests/test_soap_api_decorators.py` covering success, failed status, default-on-missing-path, non-CompoundValue passthrough, and the sync code path.

## Test plan
- [x] `poetry run pytest tests/test_soap_api_decorators.py` — 5 new tests pass
- [x] `poetry run pytest` — full suite (14 tests) passes
- [ ] Smoke test against a live NetSuite account (left for reviewer — fork doesn't have prod creds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)