### PR TITLE
feat(rest_api): add suiteql_paginated helper (upstream #42)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -122,6 +122,27 @@ async def async_main() -> dict:
         asyncio.run(async_main())
 ```
 
+## Programmatic use - SuiteQL pagination
+
+NetSuite caps a single SuiteQL response at `limit=1000` rows, and a single query overall at 100,000 rows. To stream every page of a result set without manually wiring up the `next` link, use `suiteql_paginated`:
+
+```python
+async def fetch_all_transactions():
+    rows = []
+    async for page in ns.rest_api.suiteql_paginated(
+        q="SELECT id, tranid FROM transaction",
+        limit=1000,
+    ):
+        rows.extend(page["items"])
+    return rows
+```
+
+Each yielded `page` is the raw NetSuite response dict (with `items`, `count`, `hasMore`, `links`, …). Iteration stops automatically when `hasMore` is False.
+
+To retrieve more than 100,000 rows from a query, partition by a WHERE clause and run multiple paginated queries — for example by `id` ranges or date windows.
+
+> **`ORDER BY` caveat.** NetSuite has a known quirk where a SuiteQL query with `ORDER BY` and a small `limit` (the default 10) can return zero items. Either request a larger page (`limit=1000`) or sort client-side after fetching. See [#29](https://github.com/jacobsvante/netsuite/issues/29).
+
 ## Programmatic use - Download Large Files Using SOAP API
 When working with large files, you might find that responses are truncated if they exceed 10MB. This limitation stems from the default settings in Zeep. To overcome this, enable the `xml_huge_tree` option in the Zeep client settings.
 

--- a/netsuite/rest_api.py
+++ b/netsuite/rest_api.py
@@ -1,6 +1,6 @@
 import logging
 from functools import cached_property
-from typing import Sequence
+from typing import Any, AsyncIterator, Dict, Optional, Sequence
 
 from . import rest_api_base
 from .config import Config
@@ -8,6 +8,16 @@ from .config import Config
 logger = logging.getLogger(__name__)
 
 __all__ = ("NetSuiteRestApi",)
+
+
+def _next_link(suiteql_response: Dict[str, Any]) -> Optional[str]:
+    """Return the absolute URL of the `next` link from a SuiteQL response, or None."""
+    if not suiteql_response.get("hasMore"):
+        return None
+    for link in suiteql_response.get("links") or ():
+        if link.get("rel") == "next":
+            return link.get("href")
+    return None
 
 
 class NetSuiteRestApi(rest_api_base.RestApiBase):
@@ -53,8 +63,18 @@ class NetSuiteRestApi(rest_api_base.RestApiBase):
     # TODO maybe break out params vs poping?
     async def suiteql(self, q: str, limit: int = 10, offset: int = 0, **request_kw):
         """
+        Run a single SuiteQL query.
+
         Example:
         >>> suiteql(q="SELECT * FROM Transaction", limit=10, offset=0)
+
+        Note on `ORDER BY`: NetSuite has a known quirk where a SuiteQL query
+        with `ORDER BY` and a small `limit` (the default 10) can return zero
+        items. If you must order, ask for a larger page (`limit=1000`) or
+        order client-side after fetching. See jacobsvante/netsuite#29.
+
+        Note on pagination: NetSuite caps `limit` at 1000. To stream every
+        page until exhaustion, use `suiteql_paginated` instead.
 
         Documentation:
 
@@ -69,6 +89,63 @@ class NetSuiteRestApi(rest_api_base.RestApiBase):
             params={"limit": limit, "offset": offset, **request_kw.pop("params", {})},
             **request_kw,
         )
+
+    async def suiteql_paginated(
+        self,
+        q: str,
+        *,
+        limit: int = 1000,
+        offset: int = 0,
+        **request_kw,
+    ) -> AsyncIterator[Dict[str, Any]]:
+        """
+        Async generator yielding each page of a SuiteQL query, following the
+        `next` link in NetSuite's response until `hasMore` is False.
+
+        Yields the raw page dict (with `items`, `count`, `hasMore`, `links`,
+        etc.). Use `limit=1000` (the NetSuite max) to minimize round trips.
+
+        Example:
+        >>> async for page in rest_api.suiteql_paginated(q="SELECT id FROM transaction"):
+        ...     for row in page["items"]:
+        ...         ...
+
+        Caveat: a single SuiteQL query can return at most 100,000 rows in
+        total — that is a NetSuite-side cap, not a library limitation. To
+        retrieve more, partition the query with a WHERE clause (e.g. on
+        `id` ranges or date windows) and run several paginated queries.
+        See jacobsvante/netsuite#42.
+        """
+        # First page goes through the normal `suiteql` path so users get
+        # consistent header/param handling. Subsequent pages follow the
+        # absolute `next` link from each response.
+        page = await self.suiteql(q, limit=limit, offset=offset, **request_kw)
+        yield page
+
+        next_url = _next_link(page)
+        # Subsequent pages reuse the same body; only the URL (with offset)
+        # changes. We forward `**request_kw` so callers' headers/params
+        # still apply.
+        body_kw = {
+            "headers": {"Prefer": "transient", **request_kw.pop("headers", {})},
+            "json": {"q": q, **request_kw.pop("json", {})},
+        }
+        # `params` are encoded in the next URL, so we must not also pass
+        # them here — that would double-up offset/limit.
+        request_kw.pop("params", None)
+
+        while next_url is not None:
+            page = await self._request(
+                "POST",
+                # `subpath` is ignored when `url` is provided, but
+                # `_request_impl` still requires the parameter.
+                "/query/v1/suiteql",
+                url=next_url,
+                **body_kw,
+                **request_kw,
+            )
+            yield page
+            next_url = _next_link(page)
 
     async def jsonschema(self, record_type: str, **request_kw):
         headers = {

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -1,6 +1,81 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
 from netsuite import NetSuiteRestApi
 
 
 def test_expected_hostname(dummy_config):
     rest_api = NetSuiteRestApi(dummy_config)
     assert rest_api.hostname == "123456-sb1.suitetalk.api.netsuite.com"
+
+
+@pytest.mark.asyncio
+async def test_suiteql_posts_to_query_endpoint(dummy_config):
+    rest_api = NetSuiteRestApi(dummy_config)
+    rest_api._request = AsyncMock(return_value={"items": []})  # type: ignore[method-assign]
+    await rest_api.suiteql(q="SELECT id FROM customer", limit=50, offset=10)
+    rest_api._request.assert_awaited_once()
+    args, kwargs = rest_api._request.await_args
+    assert args == ("POST", "/query/v1/suiteql")
+    assert kwargs["json"] == {"q": "SELECT id FROM customer"}
+    assert kwargs["params"] == {"limit": 50, "offset": 10}
+    assert kwargs["headers"]["Prefer"] == "transient"
+
+
+def _page(items, *, has_more, next_url=None):
+    page = {"items": items, "hasMore": has_more, "links": []}
+    if next_url is not None:
+        page["links"].append({"rel": "next", "href": next_url})
+    return page
+
+
+@pytest.mark.asyncio
+async def test_suiteql_paginated_follows_next_link_until_exhausted(dummy_config):
+    """Regression test for jacobsvante/netsuite#42 — pagination must walk the
+    `next` link until `hasMore` is False, without re-sending the original
+    `params` (which would double-encode offset/limit)."""
+    rest_api = NetSuiteRestApi(dummy_config)
+    pages = [
+        _page([1, 2], has_more=True, next_url="https://example.com/page2"),
+        _page([3, 4], has_more=True, next_url="https://example.com/page3"),
+        _page([5], has_more=False),
+    ]
+    rest_api._request = AsyncMock(side_effect=pages)  # type: ignore[method-assign]
+
+    collected = []
+    async for page in rest_api.suiteql_paginated(
+        q="SELECT id FROM transaction", limit=2
+    ):
+        collected.extend(page["items"])
+
+    assert collected == [1, 2, 3, 4, 5]
+    assert rest_api._request.await_count == 3
+
+    # Subsequent calls must use the absolute `url` from the next link, and
+    # must NOT re-pass `params` (NetSuite's next URL already encodes them).
+    second_call_kwargs = rest_api._request.await_args_list[1].kwargs
+    assert second_call_kwargs.get("url") == "https://example.com/page2"
+    assert "params" not in second_call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_suiteql_paginated_stops_when_hasmore_false_on_first_page(dummy_config):
+    rest_api = NetSuiteRestApi(dummy_config)
+    rest_api._request = AsyncMock(  # type: ignore[method-assign]
+        return_value=_page([1], has_more=False)
+    )
+    pages = [page async for page in rest_api.suiteql_paginated(q="SELECT 1")]
+    assert len(pages) == 1
+    rest_api._request.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_suiteql_paginated_stops_when_no_next_link(dummy_config):
+    """`hasMore=true` but no `rel=next` link should still terminate cleanly."""
+    rest_api = NetSuiteRestApi(dummy_config)
+    rest_api._request = AsyncMock(  # type: ignore[method-assign]
+        return_value=_page([1], has_more=True)  # no next_url
+    )
+    pages = [page async for page in rest_api.suiteql_paginated(q="SELECT 1")]
+    assert len(pages) == 1


### PR DESCRIPTION
## Summary

Closes [jacobsvante/netsuite#42](https://github.com/jacobsvante/netsuite/issues/42). The existing \`suiteql()\` accepted only \`limit\` + \`offset\`, and rolling your own pagination was awkward because the SuiteQL response's \`next\` link is an absolute URL with offset/limit already encoded — re-passing \`params\` would clash with it.

This PR adds \`NetSuiteRestApi.suiteql_paginated\`: an async generator that runs the initial query, then POSTs the same body to each \`links[rel=next]\` URL until \`hasMore\` is False or there is no next link. Default \`limit=1000\` (the NetSuite max).

\`\`\`python
async for page in ns.rest_api.suiteql_paginated(q="SELECT id FROM transaction"):
    for row in page[\"items\"]:
        ...
\`\`\`

Also clarifies in the \`suiteql()\` docstring + README:
- The \`ORDER BY\` + small-\`limit\` zero-row quirk (issue #29 — workaround: bigger \`limit\` or sort client-side).
- The 100,000-row hard cap is a NetSuite-side limit; partition by WHERE clause to stream more.

## Test plan
- [x] \`poetry run pytest tests/test_rest_api.py\` — 5 passed (4 new)
- [x] \`poetry run pytest\` — 13 passed (full suite)
- [ ] Smoke test against a live SuiteQL endpoint (left for reviewer — fork doesn't have prod creds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)