### PR TITLE
feat(rest_api): warn on SuiteQL ORDER BY footgun (upstream #29)

### DIFF
--- a/netsuite/rest_api.py
+++ b/netsuite/rest_api.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from functools import cached_property
 from typing import Any, AsyncIterator, Dict, Optional, Sequence
 
@@ -18,6 +19,17 @@ def _next_link(suiteql_response: Dict[str, Any]) -> Optional[str]:
         if link.get("rel") == "next":
             return link.get("href")
     return None
+
+
+# Matches an `ORDER BY` clause (case-insensitive). Word boundaries prevent
+# false positives on column names like `order_by_id`. The heuristic
+# deliberately fires on subquery ORDER BY's too, since those can also
+# surface the NetSuite empty-result quirk.
+_ORDER_BY_RE = re.compile(r"\border\s+by\b", re.IGNORECASE)
+
+# Below this threshold, `ORDER BY` is at risk of NetSuite's
+# zero-row quirk (jacobsvante/netsuite#29).
+_ORDER_BY_SAFE_LIMIT = 1000
 
 
 class NetSuiteRestApi(rest_api_base.RestApiBase):
@@ -70,8 +82,9 @@ class NetSuiteRestApi(rest_api_base.RestApiBase):
 
         Note on `ORDER BY`: NetSuite has a known quirk where a SuiteQL query
         with `ORDER BY` and a small `limit` (the default 10) can return zero
-        items. If you must order, ask for a larger page (`limit=1000`) or
-        order client-side after fetching. See jacobsvante/netsuite#29.
+        items. If you hit this, request a larger page (`limit=1000`) or sort
+        client-side after fetching. This method also logs a warning when it
+        detects the pattern. See jacobsvante/netsuite#29.
 
         Note on pagination: NetSuite caps `limit` at 1000. To stream every
         page until exhaustion, use `suiteql_paginated` instead.
@@ -80,6 +93,15 @@ class NetSuiteRestApi(rest_api_base.RestApiBase):
 
         - https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_156257799794.html#Using-SuiteQL
         """
+        if _ORDER_BY_RE.search(q) and limit < _ORDER_BY_SAFE_LIMIT:
+            logger.warning(
+                "SuiteQL query contains `ORDER BY` with limit=%d. NetSuite "
+                "has a known quirk where this combination can return zero "
+                "rows. Consider raising limit to %d or sorting client-side. "
+                "See jacobsvante/netsuite#29.",
+                limit,
+                _ORDER_BY_SAFE_LIMIT,
+            )
         return await self._request(
             "POST",
             "/query/v1/suiteql",

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import AsyncMock
 
 import pytest
@@ -79,3 +80,54 @@ async def test_suiteql_paginated_stops_when_no_next_link(dummy_config):
     )
     pages = [page async for page in rest_api.suiteql_paginated(q="SELECT 1")]
     assert len(pages) == 1
+
+
+@pytest.mark.asyncio
+async def test_suiteql_warns_on_order_by_with_small_limit(dummy_config, caplog):
+    """Regression test for jacobsvante/netsuite#29: warn when an `ORDER BY`
+    SuiteQL query is combined with a limit that may trigger NetSuite's
+    zero-row quirk."""
+    rest_api = NetSuiteRestApi(dummy_config)
+    rest_api._request = AsyncMock(return_value={"items": []})  # type: ignore[method-assign]
+    with caplog.at_level(logging.WARNING, logger="netsuite.rest_api"):
+        await rest_api.suiteql(q="SELECT id FROM subsidiary ORDER BY id")
+    assert any("ORDER BY" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_suiteql_quiet_when_order_by_with_safe_limit(dummy_config, caplog):
+    rest_api = NetSuiteRestApi(dummy_config)
+    rest_api._request = AsyncMock(return_value={"items": []})  # type: ignore[method-assign]
+    with caplog.at_level(logging.WARNING, logger="netsuite.rest_api"):
+        await rest_api.suiteql(
+            q="SELECT id FROM subsidiary ORDER BY id", limit=1000
+        )
+    assert not any("ORDER BY" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_suiteql_quiet_when_no_order_by(dummy_config, caplog):
+    rest_api = NetSuiteRestApi(dummy_config)
+    rest_api._request = AsyncMock(return_value={"items": []})  # type: ignore[method-assign]
+    with caplog.at_level(logging.WARNING, logger="netsuite.rest_api"):
+        await rest_api.suiteql(q="SELECT id FROM subsidiary")
+    assert not any("ORDER BY" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_suiteql_order_by_detection_is_case_insensitive(dummy_config, caplog):
+    rest_api = NetSuiteRestApi(dummy_config)
+    rest_api._request = AsyncMock(return_value={"items": []})  # type: ignore[method-assign]
+    with caplog.at_level(logging.WARNING, logger="netsuite.rest_api"):
+        await rest_api.suiteql(q="select id from subsidiary order by id")
+    assert any("ORDER BY" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_suiteql_order_by_detection_ignores_substrings(dummy_config, caplog):
+    """`order_by_id` as a column name shouldn't trigger the warning."""
+    rest_api = NetSuiteRestApi(dummy_config)
+    rest_api._request = AsyncMock(return_value={"items": []})  # type: ignore[method-assign]
+    with caplog.at_level(logging.WARNING, logger="netsuite.rest_api"):
+        await rest_api.suiteql(q="SELECT order_by_id FROM custom_table")
+    assert not any("ORDER BY" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Addresses [jacobsvante/netsuite#29](https://github.com/jacobsvante/netsuite/issues/29) — \`SELECT id, name FROM subsidiary ORDER BY id\` (and similar) returns an empty list because of a NetSuite-side quirk: the SuiteQL REST endpoint silently returns zero rows when \`ORDER BY\` is combined with a small \`limit\` (the default 10).

We can't fix it server-side. But we can stop users from losing hours: this PR logs a warning whenever a SuiteQL query contains \`ORDER BY\` and \`limit < 1000\`, pointing them at the workaround (raise the limit, or order client-side).

- Word-boundary regex so column/identifier substrings like \`order_by_id\` don't trigger false positives
- Case-insensitive detection (\`order by\`, \`Order By\`, \`ORDER BY\` all match)
- Workaround documented in the \`suiteql()\` docstring with a link back to the upstream issue

## Test plan
- [x] \`poetry run pytest tests/test_rest_api.py\` — 6 passed (5 new)
- [x] \`poetry run pytest\` — 14 passed (full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)