### PR TITLE
test: raise coverage from 46% to 75%; fix double-call bug in JSON encoder

### DIFF
--- a/netsuite/json.py
+++ b/netsuite/json.py
@@ -35,8 +35,7 @@ def _orjson_default(obj: Any) -> Any:
     if isinstance(obj, str):
         return str(obj)
     else:
-        encoder = _get_encoder(obj)
-        return encoder(obj)
+        return _get_encoder(obj)
 
 
 def _isoformat(o: Union[datetime.date, datetime.time]) -> str:
@@ -44,6 +43,10 @@ def _isoformat(o: Union[datetime.date, datetime.time]) -> str:
 
 
 def _get_encoder(obj: Any) -> Any:
+    """Return the encoded form of `obj` by walking its MRO for a registered
+    encoder. The function's name is a misnomer kept for backwards
+    compatibility — it returns the *encoded value*, not the encoder callable.
+    """
     for base in obj.__class__.__mro__[:-1]:
         try:
             encoder = _ENCODERS_BY_TYPE[base]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,149 @@
+"""Tests for the CLI surface — argparse wiring, version/help paths, and
+config loading helpers. Does not invoke any real NetSuite calls."""
+
+import argparse
+from unittest.mock import patch
+
+import pytest
+
+# `netsuite.cli.misc` imports the deprecated `pkg_resources`, which was
+# removed from setuptools 81+. Skip the whole CLI test module if it isn't
+# importable so the rest of the suite still runs on newer Pythons.
+pytest.importorskip("pkg_resources")
+
+import importlib  # noqa: E402
+
+cli_main_module = importlib.import_module("netsuite.cli.main")
+from netsuite.cli import helpers, misc, restlet, soap_api  # noqa: E402
+from netsuite.cli import rest_api as cli_rest_api  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# helpers.load_config_or_error
+# ---------------------------------------------------------------------------
+
+
+def test_load_config_or_error_returns_config(tmp_path):
+    ini = tmp_path / "ns.ini"
+    ini.write_text(
+        "[netsuite]\n"
+        "account = 999\n"
+        "consumer_key = ck\n"
+        "consumer_secret = cs\n"
+        "token_id = ti\n"
+        "token_secret = ts\n"
+    )
+    parser = argparse.ArgumentParser()
+    config = helpers.load_config_or_error(parser, str(ini), "netsuite")
+    assert config.account == "999"
+
+
+def test_load_config_or_error_missing_file_calls_parser_error(tmp_path):
+    parser = argparse.ArgumentParser()
+    with pytest.raises(SystemExit):
+        helpers.load_config_or_error(parser, str(tmp_path / "missing.ini"), "x")
+
+
+def test_load_config_or_error_missing_section_calls_parser_error(tmp_path):
+    ini = tmp_path / "ns.ini"
+    ini.write_text(
+        "[netsuite]\n"
+        "account = 999\n"
+        "consumer_key = ck\n"
+        "consumer_secret = cs\n"
+        "token_id = ti\n"
+        "token_secret = ts\n"
+    )
+    parser = argparse.ArgumentParser()
+    with pytest.raises(SystemExit):
+        helpers.load_config_or_error(parser, str(ini), "missing-section")
+
+
+# ---------------------------------------------------------------------------
+# misc — version
+# ---------------------------------------------------------------------------
+
+
+def test_misc_version_returns_a_string():
+    out = misc.version()
+    # Doesn't matter what version exactly — just that it's a non-empty string.
+    assert isinstance(out, str) and out
+
+
+def test_misc_add_parser_registers_version_subcommand():
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers()
+    version_parser, _ = misc.add_parser(parser, sub)
+    args = parser.parse_args(["version"])
+    assert args.func is misc.version
+
+
+# ---------------------------------------------------------------------------
+# Subparser registration — build the full CLI tree without executing it.
+# This covers argparse wiring in restlet/rest_api/soap_api.
+# ---------------------------------------------------------------------------
+
+
+def _build_full_parser():
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers()
+    misc.add_parser(parser, sub)
+    restlet.add_parser(parser, sub)
+    cli_rest_api.add_parser(parser, sub)
+    soap_api.add_parser(parser, sub)
+    return parser
+
+
+def test_full_cli_parser_builds_without_error():
+    _build_full_parser()
+
+
+def test_restlet_get_subcommand_parses_required_args():
+    parser = _build_full_parser()
+    args = parser.parse_args(["restlet", "get", "42"])
+    assert args.script_id == 42
+    assert args.deploy == 1  # default
+
+
+def test_restlet_get_accepts_custom_deploy():
+    parser = _build_full_parser()
+    args = parser.parse_args(["restlet", "get", "42", "-d", "7"])
+    assert args.deploy == 7
+
+
+def test_restlet_post_requires_payload_file(tmp_path):
+    parser = _build_full_parser()
+    payload = tmp_path / "payload.json"
+    payload.write_text('{"k": "v"}')
+    args = parser.parse_args(["restlet", "post", "42", str(payload)])
+    assert args.script_id == 42
+    # FileType opens the file for reading.
+    with args.payload_file as fh:
+        assert fh.read() == '{"k": "v"}'
+
+
+# ---------------------------------------------------------------------------
+# main() — the no-argv help path. We avoid actually invoking commands.
+# ---------------------------------------------------------------------------
+
+
+def test_main_with_no_args_prints_help_and_returns(capsys):
+    """argparse exits with code 2 when a required subparser is missing.
+    `main()` catches the resulting SystemExit-via-Exception in some Python
+    versions; in others it bubbles through as SystemExit. Either way the
+    process must not raise an unrelated exception."""
+    with patch("sys.argv", ["netsuite"]):
+        try:
+            cli_main_module.main()
+        except SystemExit:
+            # argparse can call sys.exit on missing required subcommand;
+            # that's expected behavior.
+            pass
+
+
+def test_main_handles_version_subcommand(capsys):
+    with patch("sys.argv", ["netsuite", "version"]):
+        cli_main_module.main()
+    captured = capsys.readouterr()
+    # `version` was invoked and its return value printed.
+    assert captured.out.strip()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,201 @@
+"""Tests for `netsuite.config` — `Config` properties and `from_env` /
+`from_ini` constructors."""
+
+from textwrap import dedent
+
+import pytest
+
+from netsuite.config import Config, TokenAuth, UsernamePasswordAuth
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+
+def test_is_token_auth_true(dummy_config):
+    assert dummy_config.is_token_auth is True
+
+
+def test_is_token_auth_false_for_username_password(dummy_username_password_config):
+    assert dummy_username_password_config.is_token_auth is False
+
+
+@pytest.mark.parametrize(
+    "account,expected",
+    [
+        ("123456", False),
+        ("123456_SB1", True),
+        ("123456_SB2", True),
+        ("ABCDE", False),
+        ("123456_SB10", True),
+    ],
+)
+def test_is_sandbox(account, expected, dummy_config):
+    config = Config(account=account, auth=dummy_config.auth)
+    assert config.is_sandbox is expected
+
+
+def test_account_number_strips_sandbox_suffix(dummy_config):
+    assert Config(account="123456_SB1", auth=dummy_config.auth).account_number == "123456"
+    assert Config(account="123456", auth=dummy_config.auth).account_number == "123456"
+
+
+def test_account_slugified_lowercases_and_replaces_underscore(dummy_config):
+    assert (
+        Config(account="123456_SB1", auth=dummy_config.auth).account_slugified
+        == "123456-sb1"
+    )
+
+
+# ---------------------------------------------------------------------------
+# `_reorganize_auth_keys` — splits flat dicts into top-level + nested `auth`
+# ---------------------------------------------------------------------------
+
+
+def test_reorganize_auth_keys_splits_token_fields():
+    raw = {
+        "account": "123456",
+        "consumer_key": "ck",
+        "consumer_secret": "cs",
+        "token_id": "ti",
+        "token_secret": "ts",
+        "log_level": "DEBUG",
+    }
+    out = Config._reorganize_auth_keys(raw)
+    assert out["account"] == "123456"
+    assert out["log_level"] == "DEBUG"
+    assert out["auth"] == {
+        "consumer_key": "ck",
+        "consumer_secret": "cs",
+        "token_id": "ti",
+        "token_secret": "ts",
+    }
+
+
+def test_reorganize_auth_keys_splits_username_password_fields():
+    raw = {"account": "123456", "username": "u", "password": "p"}
+    out = Config._reorganize_auth_keys(raw)
+    assert out["account"] == "123456"
+    assert out["auth"] == {"username": "u", "password": "p"}
+
+
+def test_reorganize_auth_keys_handles_no_auth_fields():
+    out = Config._reorganize_auth_keys({"account": "123456"})
+    assert out == {"account": "123456", "auth": {}}
+
+
+# ---------------------------------------------------------------------------
+# `Config.from_env`
+# ---------------------------------------------------------------------------
+
+
+def test_from_env_builds_token_config(monkeypatch):
+    monkeypatch.setenv("NETSUITE_ACCOUNT", "999_SB1")
+    monkeypatch.setenv("NETSUITE_CONSUMER_KEY", "ck" * 18)
+    monkeypatch.setenv("NETSUITE_CONSUMER_SECRET", "cs" * 18)
+    monkeypatch.setenv("NETSUITE_TOKEN_ID", "ti" * 18)
+    monkeypatch.setenv("NETSUITE_TOKEN_SECRET", "ts" * 18)
+    monkeypatch.setenv("NETSUITE_LOG_LEVEL", "INFO")
+    config = Config.from_env()
+    assert config.account == "999_SB1"
+    assert config.log_level == "INFO"
+    assert isinstance(config.auth, TokenAuth)
+    assert config.auth.consumer_key == "ck" * 18
+
+
+def test_from_env_skips_missing_keys(monkeypatch):
+    """Only env vars actually set should be forwarded — missing ones
+    must not show up as empty strings or `None`."""
+    # Strip any pre-existing NETSUITE_ vars.
+    for key in list(__import__("os").environ):
+        if key.startswith("NETSUITE_"):
+            monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("NETSUITE_ACCOUNT", "123_SB1")
+    monkeypatch.setenv("NETSUITE_USERNAME", "u")
+    monkeypatch.setenv("NETSUITE_PASSWORD", "p")
+    config = Config.from_env()
+    assert config.account == "123_SB1"
+    assert isinstance(config.auth, UsernamePasswordAuth)
+
+
+# ---------------------------------------------------------------------------
+# `Config.from_ini`
+# ---------------------------------------------------------------------------
+
+
+def _write_ini(tmp_path, body, name="netsuite.ini"):
+    path = tmp_path / name
+    path.write_text(dedent(body).lstrip())
+    return str(path)
+
+
+def test_from_ini_default_section(tmp_path):
+    path = _write_ini(
+        tmp_path,
+        """
+        [netsuite]
+        auth_type = token
+        account = 123456
+        consumer_key = ck
+        consumer_secret = cs
+        token_id = ti
+        token_secret = ts
+        """,
+    )
+    config = Config.from_ini(path=path)
+    assert config.account == "123456"
+    assert isinstance(config.auth, TokenAuth)
+    assert config.auth.consumer_key == "ck"
+
+
+def test_from_ini_custom_section(tmp_path):
+    path = _write_ini(
+        tmp_path,
+        """
+        [netsuite]
+        account = wrong
+        consumer_key = w
+        consumer_secret = w
+        token_id = w
+        token_secret = w
+
+        [prod]
+        account = 999
+        consumer_key = pck
+        consumer_secret = pcs
+        token_id = pti
+        token_secret = pts
+        """,
+    )
+    config = Config.from_ini(path=path, section="prod")
+    assert config.account == "999"
+    assert config.auth.consumer_key == "pck"
+
+
+def test_from_ini_rejects_non_token_auth(tmp_path):
+    path = _write_ini(
+        tmp_path,
+        """
+        [netsuite]
+        auth_type = oauth2
+        """,
+    )
+    with pytest.raises(RuntimeError, match="Only token auth"):
+        Config.from_ini(path=path)
+
+
+def test_from_ini_defaults_auth_type_to_token_when_unspecified(tmp_path):
+    path = _write_ini(
+        tmp_path,
+        """
+        [netsuite]
+        account = 123
+        consumer_key = ck
+        consumer_secret = cs
+        token_id = ti
+        token_secret = ts
+        """,
+    )
+    config = Config.from_ini(path=path)
+    assert config.is_token_auth

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,40 @@
+"""Tests for `netsuite.exceptions` and `netsuite.soap_api.exceptions`."""
+
+import pytest
+
+from netsuite.exceptions import (
+    NetsuiteAPIRequestError,
+    NetsuiteAPIResponseParsingError,
+)
+from netsuite.soap_api.exceptions import NetsuiteResponseError
+
+
+def test_request_error_carries_status_and_text():
+    err = NetsuiteAPIRequestError(404, "not found")
+    assert err.status_code == 404
+    assert err.response_text == "not found"
+
+
+def test_request_error_str_format():
+    err = NetsuiteAPIRequestError(500, "boom")
+    assert str(err) == "HTTP500 - boom"
+
+
+def test_response_parsing_error_subclasses_request_error():
+    """Callers catching `NetsuiteAPIRequestError` must also catch parsing
+    errors — the latter signals "we got HTTP 2xx but couldn't decode it",
+    which is still a request-level failure."""
+    err = NetsuiteAPIResponseParsingError(200, "<html>")
+    assert isinstance(err, NetsuiteAPIRequestError)
+    assert err.status_code == 200
+    assert str(err) == "HTTP200 - <html>"
+
+
+def test_request_error_can_be_raised_and_caught():
+    with pytest.raises(NetsuiteAPIRequestError):
+        raise NetsuiteAPIRequestError(401, "unauthorized")
+
+
+def test_soap_response_error_is_an_exception():
+    with pytest.raises(NetsuiteResponseError):
+        raise NetsuiteResponseError("status detail here")

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,0 +1,116 @@
+"""Tests for `netsuite.json` — the orjson-or-stdlib JSON shim."""
+
+import datetime
+import importlib
+import sys
+from decimal import Decimal
+from enum import Enum
+from pathlib import Path
+from unittest.mock import patch
+from uuid import UUID
+
+import pytest
+
+from netsuite import json as nsjson
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: dumps→loads should preserve plain dict/list/scalar payloads
+# regardless of which JSON backend is in use.
+# ---------------------------------------------------------------------------
+
+
+def test_dumps_loads_round_trips_plain_dict():
+    payload = {"a": 1, "b": "two", "c": [1, 2, 3], "d": None, "e": True}
+    assert nsjson.loads(nsjson.dumps(payload)) == payload
+
+
+def test_dumps_returns_str_not_bytes():
+    """Even with orjson (which natively returns bytes) we must hand back str."""
+    out = nsjson.dumps({"a": 1})
+    assert isinstance(out, str)
+
+
+# ---------------------------------------------------------------------------
+# Custom encoders for non-standard types. These only matter for orjson, since
+# stdlib json would raise TypeError without `default=` — but the round-trip
+# should succeed regardless of which backend is loaded.
+# ---------------------------------------------------------------------------
+
+
+class _Color(Enum):
+    RED = "red"
+    BLUE = "blue"
+
+
+@pytest.mark.parametrize(
+    "value,expected_decoded",
+    [
+        (datetime.date(2024, 1, 2), "2024-01-02"),
+        (datetime.datetime(2024, 1, 2, 3, 4, 5), "2024-01-02T03:04:05"),
+        (datetime.time(3, 4, 5), "03:04:05"),
+        (datetime.timedelta(seconds=90), 90.0),
+        (Decimal("1.5"), 1.5),
+        (_Color.RED, "red"),
+        (frozenset([1, 2, 3]), [1, 2, 3]),
+        (set([1, 2, 3]), [1, 2, 3]),
+        (Path("/tmp/x"), "/tmp/x"),
+        (UUID("12345678-1234-5678-1234-567812345678"), "12345678-1234-5678-1234-567812345678"),
+    ],
+)
+def test_dumps_encodes_supported_types(value, expected_decoded):
+    decoded = nsjson.loads(nsjson.dumps({"v": value}))
+    if isinstance(expected_decoded, list):
+        # set/frozenset have non-deterministic iteration order
+        assert sorted(decoded["v"]) == sorted(expected_decoded)
+    else:
+        assert decoded["v"] == expected_decoded
+
+
+def test_dumps_bytes_decodes_as_utf8():
+    assert nsjson.loads(nsjson.dumps({"v": b"hello"})) == {"v": "hello"}
+
+
+def test_dumps_str_subclass_is_normalized():
+    """orjson rejects str subclasses by default — `_orjson_default` falls
+    back to `str(obj)` for them."""
+
+    class StrSub(str):
+        pass
+
+    if not nsjson.HAS_ORJSON:
+        pytest.skip("Only orjson rejects str subclasses without a default hook")
+    assert nsjson.loads(nsjson.dumps({"v": StrSub("x")})) == {"v": "x"}
+
+
+def test_dumps_unsupported_type_raises():
+    """Types with no encoder should raise from `_get_encoder`."""
+
+    class Nope:
+        pass
+
+    if not nsjson.HAS_ORJSON:
+        pytest.skip(
+            "Stdlib json raises TypeError directly without going through _get_encoder"
+        )
+    with pytest.raises(TypeError, match="Nope"):
+        nsjson.dumps({"v": Nope()})
+
+
+# ---------------------------------------------------------------------------
+# Backend selection — exercise the stdlib fallback by reloading the module
+# with orjson hidden.
+# ---------------------------------------------------------------------------
+
+
+def test_stdlib_fallback_is_used_when_orjson_unavailable():
+    real_orjson = sys.modules.pop("orjson", None)
+    try:
+        with patch.dict(sys.modules, {"orjson": None}):
+            reloaded = importlib.reload(nsjson)
+            assert reloaded.HAS_ORJSON is False
+            assert reloaded.loads(reloaded.dumps({"a": 1})) == {"a": 1}
+    finally:
+        if real_orjson is not None:
+            sys.modules["orjson"] = real_orjson
+        importlib.reload(nsjson)

--- a/tests/test_rest_api_base.py
+++ b/tests/test_rest_api_base.py
@@ -1,0 +1,316 @@
+"""Tests for `RestApiBase` — the shared HTTP plumbing under both
+`NetSuiteRestApi` and `NetSuiteRestlet`."""
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from netsuite.exceptions import (
+    NetsuiteAPIRequestError,
+    NetsuiteAPIResponseParsingError,
+)
+from netsuite.rest_api_base import (
+    DEFAULT_SIGNATURE_METHOD,
+    RestApiBase,
+    authlib_hmac_sha256_sign_method,
+)
+
+
+class _ConcreteApi(RestApiBase):
+    """Minimal concretion so we can exercise `RestApiBase` directly."""
+
+    def __init__(self, config):
+        self._config = config
+        self._default_timeout = 10
+        self._concurrent_requests = 5
+
+    def _make_url(self, subpath):
+        return f"https://example.com{subpath}"
+
+
+def _httpx_response(status_code, text, headers=None):
+    request = httpx.Request("GET", "https://example.com/x")
+    return httpx.Response(
+        status_code, content=text.encode("utf-8"), headers=headers or {}, request=request
+    )
+
+
+# ---------------------------------------------------------------------------
+# `_request` — wraps `_request_impl` with status checks and JSON decoding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_request_returns_decoded_json_on_2xx(dummy_config):
+    api = _ConcreteApi(dummy_config)
+    api._request_impl = AsyncMock(
+        return_value=_httpx_response(200, '{"ok": true}')
+    )
+    assert await api._request("GET", "/x") == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_request_returns_none_on_204(dummy_config):
+    api = _ConcreteApi(dummy_config)
+    api._request_impl = AsyncMock(return_value=_httpx_response(204, ""))
+    assert await api._request("DELETE", "/x") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [400, 401, 403, 404, 500, 503])
+async def test_request_raises_on_non_2xx(dummy_config, status_code):
+    api = _ConcreteApi(dummy_config)
+    api._request_impl = AsyncMock(
+        return_value=_httpx_response(status_code, "boom")
+    )
+    with pytest.raises(NetsuiteAPIRequestError) as excinfo:
+        await api._request("GET", "/x")
+    assert excinfo.value.status_code == status_code
+    assert excinfo.value.response_text == "boom"
+    assert str(status_code) in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_request_raises_parse_error_on_invalid_json(dummy_config):
+    api = _ConcreteApi(dummy_config)
+    api._request_impl = AsyncMock(
+        return_value=_httpx_response(200, "<html>not json</html>")
+    )
+    with pytest.raises(NetsuiteAPIResponseParsingError) as excinfo:
+        await api._request("GET", "/x")
+    # The parse error subclasses request error and carries the same payload.
+    assert excinfo.value.status_code == 200
+    assert excinfo.value.response_text == "<html>not json</html>"
+
+
+# ---------------------------------------------------------------------------
+# `_request_impl` — argument shaping into httpx
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_request_impl_uses_make_url_when_no_url_kwarg(dummy_config):
+    api = _ConcreteApi(dummy_config)
+    captured = {}
+
+    class _FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def request(self, **kw):
+            captured.update(kw)
+            return _httpx_response(200, "{}")
+
+    with patch("netsuite.rest_api_base.httpx.AsyncClient", return_value=_FakeClient()):
+        await api._request_impl("get", "/widgets", params={"a": 1})
+
+    # `method` must be uppercased; URL comes from `_make_url`.
+    assert captured["method"] == "GET"
+    assert captured["url"] == "https://example.com/widgets"
+    assert captured["params"] == {"a": 1}
+    # Default headers must be merged in.
+    assert captured["headers"]["Content-Type"] == "application/json"
+    assert captured["timeout"] == 10  # `_default_timeout`
+
+
+@pytest.mark.asyncio
+async def test_request_impl_url_kwarg_overrides_subpath(dummy_config):
+    """Passing `url=` must bypass `_make_url` — used by SuiteQL pagination
+    and `token_info`."""
+    api = _ConcreteApi(dummy_config)
+    captured = {}
+
+    class _FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def request(self, **kw):
+            captured.update(kw)
+            return _httpx_response(200, "{}")
+
+    with patch("netsuite.rest_api_base.httpx.AsyncClient", return_value=_FakeClient()):
+        await api._request_impl(
+            "POST", "ignored", url="https://override.example.com/foo"
+        )
+
+    assert captured["url"] == "https://override.example.com/foo"
+
+
+@pytest.mark.asyncio
+async def test_request_impl_serializes_json_to_data(dummy_config):
+    """`json=` must be popped, dumped to a string, and forwarded as `data=`.
+    httpx would otherwise re-serialize and double-encode."""
+    api = _ConcreteApi(dummy_config)
+    captured = {}
+
+    class _FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def request(self, **kw):
+            captured.update(kw)
+            return _httpx_response(200, "{}")
+
+    with patch("netsuite.rest_api_base.httpx.AsyncClient", return_value=_FakeClient()):
+        await api._request_impl("POST", "/x", json={"q": "SELECT 1"})
+
+    assert "json" not in captured
+    assert captured["data"] == '{"q": "SELECT 1"}' or captured["data"] == '{"q":"SELECT 1"}'
+
+
+@pytest.mark.asyncio
+async def test_request_impl_caller_headers_override_defaults(dummy_config):
+    api = _ConcreteApi(dummy_config)
+    captured = {}
+
+    class _FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def request(self, **kw):
+            captured.update(kw)
+            return _httpx_response(200, "{}")
+
+    with patch("netsuite.rest_api_base.httpx.AsyncClient", return_value=_FakeClient()):
+        await api._request_impl(
+            "GET",
+            "/x",
+            headers={"Content-Type": "application/schema+json", "X-Extra": "1"},
+        )
+
+    assert captured["headers"]["Content-Type"] == "application/schema+json"
+    assert captured["headers"]["X-Extra"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_request_impl_caller_timeout_overrides_default(dummy_config):
+    api = _ConcreteApi(dummy_config)
+    captured = {}
+
+    class _FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def request(self, **kw):
+            captured.update(kw)
+            return _httpx_response(200, "{}")
+
+    with patch("netsuite.rest_api_base.httpx.AsyncClient", return_value=_FakeClient()):
+        await api._request_impl("GET", "/x", timeout=99)
+
+    assert captured["timeout"] == 99
+
+
+@pytest.mark.asyncio
+async def test_request_impl_logs_at_debug_level(dummy_config, caplog):
+    api = _ConcreteApi(dummy_config)
+
+    class _FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def request(self, **kw):
+            return _httpx_response(200, "{}", headers={"X-Foo": "bar"})
+
+    with patch("netsuite.rest_api_base.httpx.AsyncClient", return_value=_FakeClient()):
+        with caplog.at_level(logging.DEBUG, logger="netsuite.rest_api_base"):
+            await api._request_impl("GET", "/x")
+
+    debug_msgs = [r.message for r in caplog.records]
+    assert any("Making GET request" in m for m in debug_msgs)
+    assert any("response headers" in m for m in debug_msgs)
+
+
+# ---------------------------------------------------------------------------
+# `_make_url` is abstract; `_make_auth` and `_make_default_headers` defaults
+# ---------------------------------------------------------------------------
+
+
+def test_base_make_url_is_abstract(dummy_config):
+    api = RestApiBase()
+    api._config = dummy_config
+    with pytest.raises(NotImplementedError):
+        api._make_url("/x")
+
+
+def test_base_default_headers(dummy_config):
+    assert RestApiBase()._make_default_headers() == {"Content-Type": "application/json"}
+
+
+def test_make_auth_passes_token_credentials(dummy_config):
+    api = _ConcreteApi(dummy_config)
+    api._signature_method = DEFAULT_SIGNATURE_METHOD
+    auth = api._make_auth()
+    # OAuth1Auth stores credentials directly as attributes on itself.
+    assert auth.client_id == dummy_config.auth.consumer_key
+    assert auth.client_secret == dummy_config.auth.consumer_secret
+    assert auth.token == dummy_config.auth.token_id
+    assert auth.token_secret == dummy_config.auth.token_secret
+    assert auth.realm == dummy_config.account
+
+
+# ---------------------------------------------------------------------------
+# Concurrency control
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_request_semaphore_is_lazily_created_and_caches(dummy_config):
+    api = _ConcreteApi(dummy_config)
+    sem = api._request_semaphore
+    assert isinstance(sem, asyncio.Semaphore)
+    # Cached: second access returns the same instance.
+    assert api._request_semaphore is sem
+
+
+# ---------------------------------------------------------------------------
+# HMAC-SHA256 signing
+# ---------------------------------------------------------------------------
+
+
+def test_authlib_hmac_sha256_signs_via_oauthlib():
+    """The custom signing method should defer to oauthlib's `sign_hmac_sha256`
+    using authlib's signature base string."""
+    fake_request = MagicMock()
+    fake_client = MagicMock(client_secret="secret", token_secret="ts")
+    with patch(
+        "netsuite.rest_api_base.generate_signature_base_string",
+        return_value="base",
+    ) as mock_base, patch(
+        "netsuite.rest_api_base.sign_hmac_sha256",
+        return_value="signed",
+    ) as mock_sign:
+        sig = authlib_hmac_sha256_sign_method(fake_client, fake_request)
+
+    mock_base.assert_called_once_with(fake_request)
+    mock_sign.assert_called_once_with("base", "secret", "ts")
+    assert sig == "signed"
+
+
+def test_hmac_sha256_method_is_registered_on_authlib():
+    """Importing `rest_api_base` should register HMAC-SHA256 with authlib's
+    `ClientAuth`. This is what lets `_make_auth` produce SHA256 signatures."""
+    from authlib.oauth1.rfc5849.client_auth import ClientAuth
+
+    assert "HMAC-SHA256" in ClientAuth.SIGNATURE_METHODS

--- a/tests/test_restlet.py
+++ b/tests/test_restlet.py
@@ -1,6 +1,63 @@
+"""Tests for `NetSuiteRestlet`. Previously only `hostname` was tested."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
 from netsuite import NetSuiteRestlet
 
 
 def test_expected_hostname(dummy_config):
     restlet = NetSuiteRestlet(dummy_config)
     assert restlet.hostname == "123456-sb1.restlets.api.netsuite.com"
+
+
+def test_hostname_for_production_account(dummy_config_with_production_account):
+    restlet = NetSuiteRestlet(dummy_config_with_production_account)
+    assert restlet.hostname == "123456.restlets.api.netsuite.com"
+
+
+def test_make_url_includes_restlet_path(dummy_config):
+    restlet = NetSuiteRestlet(dummy_config)
+    url = restlet._make_url("?script=42&deploy=1")
+    assert (
+        url
+        == "https://123456-sb1.restlets.api.netsuite.com/app/site/hosting/restlet.nl?script=42&deploy=1"
+    )
+
+
+def test_make_restlet_params_default_deploy(dummy_config):
+    restlet = NetSuiteRestlet(dummy_config)
+    assert restlet._make_restlet_params(123) == "?script=123&deploy=1"
+
+
+def test_make_restlet_params_custom_deploy(dummy_config):
+    restlet = NetSuiteRestlet(dummy_config)
+    assert restlet._make_restlet_params(123, deploy=7) == "?script=123&deploy=7"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "verb,expected_method",
+    [("get", "GET"), ("post", "POST"), ("put", "PUT"), ("delete", "DELETE")],
+)
+async def test_each_verb_calls_request_with_script_subpath(
+    dummy_config, verb, expected_method
+):
+    restlet = NetSuiteRestlet(dummy_config)
+    restlet._request = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    method = getattr(restlet, verb)
+    await method(123, deploy=2, json={"foo": "bar"})
+    restlet._request.assert_awaited_once()
+    args, kwargs = restlet._request.await_args
+    assert args == (expected_method, "?script=123&deploy=2")
+    assert kwargs["json"] == {"foo": "bar"}
+
+
+@pytest.mark.asyncio
+async def test_default_deploy_is_one(dummy_config):
+    restlet = NetSuiteRestlet(dummy_config)
+    restlet._request = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    await restlet.get(987)
+    args, _ = restlet._request.await_args
+    assert args == ("GET", "?script=987&deploy=1")

--- a/tests/test_soap_api_decorators_edge_cases.py
+++ b/tests/test_soap_api_decorators_edge_cases.py
@@ -1,0 +1,82 @@
+"""Edge-case tests for `WebServiceCall` not covered in
+`test_soap_api_decorators.py`.
+
+Focus: the list-status code path (TypeError when indexing the response with
+"status" because it's iterable rather than a mapping), and the unset-default
+re-raise."""
+
+import pytest
+
+from netsuite.soap_api.exceptions import NetsuiteResponseError
+from netsuite.soap_api.zeep import ZEEP_INSTALLED
+
+pytestmark = pytest.mark.skipif(not ZEEP_INSTALLED, reason="Requires zeep")
+
+if ZEEP_INSTALLED:
+    from zeep.xsd.valueobjects import CompoundValue
+
+    from netsuite.soap_api.decorators import WebServiceCall
+
+
+class _AttrAndItemResponse(CompoundValue):
+    def __init__(self, **attrs):
+        object.__setattr__(self, "_attrs", attrs)
+
+    def __getattr__(self, name):
+        attrs = object.__getattribute__(self, "_attrs")
+        if name in attrs:
+            return attrs[name]
+        raise AttributeError(name)
+
+    def __getitem__(self, key):
+        return object.__getattribute__(self, "_attrs")[key]
+
+
+@pytest.mark.asyncio
+async def test_decorator_status_via_list_iteration_when_indexing_raises():
+    """When path traversal lands on a plain list (e.g. a record list), the
+    decorator's `response['status']` raises TypeError. It must then iterate
+    the list and pull `status` from the first record."""
+
+    record = _AttrAndItemResponse(status={"isSuccess": True, "statusDetail": []})
+    # `body.records` resolves to a plain Python list — `list['status']`
+    # raises TypeError, exercising the fallback iteration path.
+    outer = _AttrAndItemResponse(body=_AttrAndItemResponse(records=[record]))
+
+    @WebServiceCall("body.records", extract=lambda resp: list(resp))
+    async def fake_op(self):
+        return outer
+
+    out = await fake_op(object())
+    assert out == [record]
+
+
+@pytest.mark.asyncio
+async def test_decorator_status_via_list_iteration_propagates_error():
+    record = _AttrAndItemResponse(
+        status={"isSuccess": False, "statusDetail": "first record failed"}
+    )
+    outer = _AttrAndItemResponse(body=_AttrAndItemResponse(records=[record]))
+
+    @WebServiceCall("body.records")
+    async def fake_op(self):
+        return outer
+
+    with pytest.raises(NetsuiteResponseError):
+        await fake_op(object())
+
+
+@pytest.mark.asyncio
+async def test_decorator_reraises_attribute_error_when_default_unset():
+    """If walking `path` hits an AttributeError and no `default` was
+    supplied, the original AttributeError should propagate rather than be
+    silently swallowed."""
+
+    outer = _AttrAndItemResponse(body=_AttrAndItemResponse())  # no `readResponse`
+
+    @WebServiceCall("body.readResponse")  # no default
+    async def fake_get(self):
+        return outer
+
+    with pytest.raises(AttributeError):
+        await fake_get(object())

--- a/tests/test_soap_api_passport.py
+++ b/tests/test_soap_api_passport.py
@@ -1,0 +1,131 @@
+"""Tests for SOAP TokenPassport — signature/nonce/timestamp generation, and
+the `make` factory that wraps it for outbound headers."""
+
+import re
+from unittest.mock import MagicMock
+
+import pytest
+
+from netsuite.config import Config
+from netsuite.soap_api.passport import Passport, TokenPassport, make as make_passport
+from netsuite.soap_api.zeep import ZEEP_INSTALLED
+
+pytestmark = pytest.mark.skipif(not ZEEP_INSTALLED, reason="Requires zeep")
+
+
+def _make_passport(config):
+    auth = config.auth
+    fake_ns = MagicMock()
+    return TokenPassport(
+        fake_ns,
+        account=config.account,
+        consumer_key=auth.consumer_key,
+        consumer_secret=auth.consumer_secret,
+        token_id=auth.token_id,
+        token_secret=auth.token_secret,
+    )
+
+
+def test_base_passport_get_element_is_abstract():
+    with pytest.raises(NotImplementedError):
+        Passport().get_element()
+
+
+def test_generate_timestamp_is_unix_seconds(dummy_config):
+    passport = _make_passport(dummy_config)
+    ts = passport._generate_timestamp()
+    # Sanity-check: NetSuite's accepted timestamps are seconds since epoch.
+    assert ts.isdigit()
+    assert int(ts) > 1_500_000_000  # post-2017
+
+
+def test_generate_nonce_is_digits_with_default_length(dummy_config):
+    passport = _make_passport(dummy_config)
+    nonce = passport._generate_nonce()
+    assert re.fullmatch(r"\d{20}", nonce)
+
+
+def test_generate_nonce_respects_custom_length(dummy_config):
+    passport = _make_passport(dummy_config)
+    nonce = passport._generate_nonce(length=8)
+    assert re.fullmatch(r"\d{8}", nonce)
+
+
+def test_signature_message_components(dummy_config):
+    passport = _make_passport(dummy_config)
+    msg = passport._get_signature_message(nonce="N", timestamp="T")
+    assert msg == "&".join(
+        [
+            dummy_config.account,
+            dummy_config.auth.consumer_key,
+            dummy_config.auth.token_id,
+            "N",
+            "T",
+        ]
+    )
+
+
+def test_signature_key_combines_secrets(dummy_config):
+    passport = _make_passport(dummy_config)
+    key = passport._get_signature_key()
+    assert (
+        key
+        == f"{dummy_config.auth.consumer_secret}&{dummy_config.auth.token_secret}"
+    )
+
+
+def test_signature_value_changes_when_inputs_change(dummy_config):
+    passport = _make_passport(dummy_config)
+    assert passport._get_signature_value("a", "1") != passport._get_signature_value(
+        "a", "2"
+    )
+    assert passport._get_signature_value("a", "1") != passport._get_signature_value(
+        "b", "1"
+    )
+
+
+def test_get_signature_uses_core_token_passport_signature(dummy_config):
+    """`_get_signature` should construct a `Core.TokenPassportSignature` with
+    the HMAC-SHA256 algorithm marker."""
+    passport = _make_passport(dummy_config)
+    passport.ns.Core.TokenPassportSignature = MagicMock(return_value="sig-obj")
+    result = passport._get_signature(nonce="N", timestamp="T")
+    passport.ns.Core.TokenPassportSignature.assert_called_once()
+    args, kwargs = passport.ns.Core.TokenPassportSignature.call_args
+    assert kwargs == {"algorithm": "HMAC-SHA256"}
+    # The first positional is the base64 signature value.
+    assert isinstance(args[0], str)
+    assert result == "sig-obj"
+
+
+def test_get_element_returns_token_passport_with_all_fields(dummy_config):
+    passport = _make_passport(dummy_config)
+    passport.ns.Core.TokenPassportSignature = MagicMock(return_value="sig")
+    passport.ns.Core.TokenPassport = MagicMock(return_value="token-passport")
+    result = passport.get_element()
+    passport.ns.Core.TokenPassport.assert_called_once()
+    kwargs = passport.ns.Core.TokenPassport.call_args.kwargs
+    assert kwargs["account"] == dummy_config.account
+    assert kwargs["consumerKey"] == dummy_config.auth.consumer_key
+    assert kwargs["token"] == dummy_config.auth.token_id
+    assert kwargs["nonce"].isdigit()
+    assert kwargs["timestamp"].isdigit()
+    assert kwargs["signature"] == "sig"
+    assert result == "token-passport"
+
+
+def test_make_returns_token_passport_dict_for_token_auth(dummy_config):
+    fake_ns = MagicMock()
+    fake_ns.Core.TokenPassport.return_value = "tp"
+    fake_ns.Core.TokenPassportSignature.return_value = "sig"
+    out = make_passport(fake_ns, dummy_config)
+    assert "tokenPassport" in out
+
+
+def test_make_rejects_username_password_auth():
+    config = Config(
+        account="123456_SB1",
+        auth={"username": "u", "password": "p"},
+    )
+    with pytest.raises(NotImplementedError):
+        make_passport(MagicMock(), config)

--- a/tests/test_soap_api_transports.py
+++ b/tests/test_soap_api_transports.py
@@ -1,0 +1,94 @@
+"""Tests for `AsyncNetSuiteTransport` — the zeep transport that forces
+each request to the account-specific NetSuite subdomain."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from netsuite.soap_api.transports import AsyncNetSuiteTransport
+from netsuite.soap_api.zeep import ZEEP_INSTALLED
+
+pytestmark = pytest.mark.skipif(not ZEEP_INSTALLED, reason="Requires zeep")
+
+
+def test_init_extracts_base_url_from_wsdl_url():
+    transport = AsyncNetSuiteTransport(
+        "https://123-sb1.suitetalk.api.netsuite.com/wsdl/v2021_1_0/netsuite.wsdl",
+    )
+    assert (
+        transport._netsuite_base_url
+        == "https://123-sb1.suitetalk.api.netsuite.com"
+    )
+
+
+def test_init_handles_url_without_path():
+    transport = AsyncNetSuiteTransport("https://example.com")
+    assert transport._netsuite_base_url == "https://example.com"
+
+
+def test_fix_address_swaps_default_host_for_account_host():
+    transport = AsyncNetSuiteTransport(
+        "https://123-sb1.suitetalk.api.netsuite.com/wsdl/v2021_1_0/netsuite.wsdl",
+    )
+    assert (
+        transport._fix_address(
+            "https://webservices.netsuite.com/services/NetSuitePort_2021_1"
+        )
+        == "https://123-sb1.suitetalk.api.netsuite.com/services/NetSuitePort_2021_1"
+    )
+
+
+def test_fix_address_preserves_query_string():
+    transport = AsyncNetSuiteTransport(
+        "https://acct.suitetalk.api.netsuite.com/wsdl/v2021_1_0/netsuite.wsdl",
+    )
+    fixed = transport._fix_address(
+        "https://webservices.netsuite.com/services/NetSuitePort_2021_1?wsdl"
+    )
+    assert fixed == "https://acct.suitetalk.api.netsuite.com/services/NetSuitePort_2021_1?wsdl"
+
+
+@pytest.mark.asyncio
+async def test_get_passes_through_fixed_address():
+    transport = AsyncNetSuiteTransport(
+        "https://acct.suitetalk.api.netsuite.com/wsdl/v.wsdl",
+    )
+    with patch(
+        "zeep.transports.AsyncTransport.get",
+        new_callable=AsyncMock,
+        return_value="resp",
+    ) as parent_get:
+        result = await transport.get(
+            "https://webservices.netsuite.com/services/foo",
+            params={"k": "v"},
+            headers={"H": "1"},
+        )
+    assert result == "resp"
+    parent_get.assert_awaited_once_with(
+        "https://acct.suitetalk.api.netsuite.com/services/foo",
+        {"k": "v"},
+        {"H": "1"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_passes_through_fixed_address():
+    transport = AsyncNetSuiteTransport(
+        "https://acct.suitetalk.api.netsuite.com/wsdl/v.wsdl",
+    )
+    with patch(
+        "zeep.transports.AsyncTransport.post",
+        new_callable=AsyncMock,
+        return_value="resp",
+    ) as parent_post:
+        result = await transport.post(
+            "https://webservices.netsuite.com/services/foo",
+            "<xml/>",
+            {"H": "1"},
+        )
+    assert result == "resp"
+    parent_post.assert_awaited_once_with(
+        "https://acct.suitetalk.api.netsuite.com/services/foo",
+        "<xml/>",
+        {"H": "1"},
+    )


### PR DESCRIPTION
## Summary

Adds 100 tests across 8 new files and raises overall coverage from **46% → 75%**.

Per-module gains:

| Module | Before | After |
|---|---|---|
| \`config.py\` | 59% | **100%** |
| \`exceptions.py\` | 57% | **100%** |
| \`json.py\` | 46% | **94%** |
| \`rest_api_base.py\` | 46% | **100%** |
| \`restlet.py\` | 70% | **100%** |
| \`soap_api/decorators.py\` | 88% | **100%** |
| \`soap_api/passport.py\` | 77% | **100%** |
| \`soap_api/transports.py\` | 88% | **100%** |
| \`cli/helpers.py\` | 0% | **92%** |
| \`cli/main.py\` | 0% | **55%** |
| \`cli/misc.py\` | 0% | **100%** |
| \`cli/rest_api.py\` | 0% | **51%** |
| \`cli/restlet.py\` | 0% | **63%** |
| \`cli/soap_api.py\` | 0% | **69%** |

What's tested:

- **\`rest_api_base\`** — \`_request\` (success / 204 / 4xx / 5xx / parse error), \`_request_impl\` (URL override, header merging, JSON-to-data conversion, timeout overrides, debug logging, semaphore caching), \`_make_auth\` builds OAuth1Auth, custom HMAC-SHA256 signing method registration.
- **\`config\`** — every property, \`_reorganize_auth_keys\` for token/username-password/empty inputs, \`from_env\` partial-environment behavior, \`from_ini\` default/custom sections + non-token rejection.
- **\`json\`** — round-trip through both backends, encoder coverage for date/datetime/time/timedelta/Decimal/Enum/set/frozenset/Path/UUID/bytes/str-subclass, unsupported-type error, stdlib fallback when orjson is hidden via \`importlib.reload\`.
- **\`restlet\`** — every verb, default and custom \`deploy\`, hostname for sandbox/prod, URL composition.
- **\`soap_api/passport\`** — abstract base, timestamp/nonce shape, signature determinism, \`Core.TokenPassportSignature\`/\`Core.TokenPassport\` construction, \`make\` token-vs-username-password dispatch.
- **\`soap_api/decorators\`** edge cases — list-iteration fallback when \`response[\"status\"]\` raises TypeError, AttributeError re-raise when no \`default\` is supplied.
- **\`soap_api/transports\`** — base-URL extraction, address-host swap with/without query string, \`get\`/\`post\` delegate to fixed addresses.
- **\`exceptions\`** — \`HTTP{n} - {text}\` formatting, parse error subclasses request error.
- **\`cli\`** — argparse wiring builds without errors, subcommand argument parsing, \`version\` end-to-end, config-loading errors call \`parser.error\`.

## Bug fix included

While writing tests for \`netsuite.json\` I hit a 5-year-old bug in \`_orjson_default\`:

\`\`\`python
encoder = _get_encoder(obj)   # this already returns the *encoded value*
return encoder(obj)            # ...so this calls e.g. \"hello\"(b\"hello\") -> TypeError
\`\`\`

Any payload containing a \`Decimal\`, \`bytes\`, \`set\`, \`frozenset\`, \`Path\`, or \`timedelta\` would crash with \`'str' object is not callable\` when orjson is the active backend. Fixed by removing the redundant invocation; \`_get_encoder\`'s docstring is updated to reflect that it returns the encoded value (the function name is a misnomer kept for backwards compatibility).

## CLI tests on newer Python

\`netsuite.cli.misc\` imports the deprecated \`pkg_resources\`, which was dropped from setuptools 81 (released April 2024) and is missing on Python 3.14. The CLI test module gates on \`pytest.importorskip(\"pkg_resources\")\` so the rest of the suite still runs cleanly. Migrating \`misc.version()\` to \`importlib.metadata\` is a worthwhile follow-up.

## Test plan
- [x] \`pytest --cov=netsuite\` → 149 passed, 75% coverage
- [x] No production code paths altered besides the json encoder fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)