### PR TITLE
feat(soap_api): bump default WSDL version 2021.1.0 -> 2024.2.0

### DIFF
--- a/netsuite/soap_api/client.py
+++ b/netsuite/soap_api/client.py
@@ -25,7 +25,7 @@ SOAP_DEPRECATION_MESSAGE = (
 
 
 class NetSuiteSoapApi:
-    version = getattr(Config, "wsdl_version", "2021.1.0")
+    version = getattr(Config, "wsdl_version", "2024.2.0")
     wsdl_url_tmpl = "https://{account_slug}.suitetalk.api.netsuite.com/wsdl/v{underscored_version}/netsuite.wsdl"
 
     def __init__(

--- a/tests/test_soap_api.py
+++ b/tests/test_soap_api.py
@@ -27,7 +27,7 @@ def test_netsuite_wsdl_url(dummy_config):
     soap_api = NetSuiteSoapApi(dummy_config)
     assert (
         soap_api.wsdl_url
-        == "https://123456-sb1.suitetalk.api.netsuite.com/wsdl/v2021_1_0/netsuite.wsdl"
+        == "https://123456-sb1.suitetalk.api.netsuite.com/wsdl/v2024_2_0/netsuite.wsdl"
     )
 
 
@@ -35,7 +35,7 @@ def test_netsuite_wsdl_url_production_account(dummy_config_with_production_accou
     soap_api = NetSuiteSoapApi(dummy_config_with_production_account)
     assert (
         soap_api.wsdl_url
-        == "https://123456.suitetalk.api.netsuite.com/wsdl/v2021_1_0/netsuite.wsdl"
+        == "https://123456.suitetalk.api.netsuite.com/wsdl/v2024_2_0/netsuite.wsdl"
     )
 
 


### PR DESCRIPTION
## Summary

Imports [jacobsvante/netsuite#99](https://github.com/jacobsvante/netsuite/pull/99) (merit-finns).

NetSuite has told integrators that SOAP web service WSDL versions 2017.2 through 2021.1 are unsupported and integrations on those versions need to upgrade. Until our [2027.1 SOAP sunset](https://github.com/vlouvet/netsuite/pull/11) arrives, the lib's default WSDL needs to be one NetSuite still serves.

\`NetSuiteSoapApi(version=...)\` still lets users pin to any version their NetSuite account requires.

## Test plan
- [x] Updated test fixtures so the new \`v2024_2_0\` URL is the expected default
- [x] \`pytest -q\` — 183 passed
- [x] \`black\`/\`isort\`/\`flake8\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)