### PR TITLE
build(deps-dev): pytest-cov ~5 -> ~6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ mkdocs-material = "~9"
 mypy = ">=1,<3"
 pytest = "~8"
 pytest-asyncio = "~0.23"
-pytest-cov = "~5"
+pytest-cov = "~6"
 types-setuptools = "^75.8.2"
 types-requests = "^2.27.30"
 


### PR DESCRIPTION
Imports [jacobsvante/netsuite#108](https://github.com/jacobsvante/netsuite/pull/108). pytest-cov 6 drops Py3.8 support; we're already on Py3.9+ so no floor change.