### PR TITLE
feat(rest_api): add create_record helper that returns the new record ID (upstream #121)

### DIFF
--- a/netsuite/rest_api.py
+++ b/netsuite/rest_api.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from functools import cached_property
-from typing import Any, AsyncIterator, Dict, Optional, Sequence
+from typing import Any, AsyncIterator, Dict, Optional, Sequence, Union
 
 from . import rest_api_base
 from .config import Config
@@ -71,6 +71,33 @@ class NetSuiteRestApi(rest_api_base.RestApiBase):
 
     async def delete(self, subpath: str, **request_kw):
         return await self._request("DELETE", subpath, **request_kw)
+
+    async def create_record(
+        self,
+        record_type: str,
+        record_data: Dict[str, Any],
+        **request_kw,
+    ) -> Union[int, str]:
+        """Create a new record and return its ID.
+
+        NetSuite's REST API responds to a successful POST create with HTTP
+        204 plus a `Location` header pointing at the new record. This
+        helper POSTs to ``/record/v1/{record_type}`` and returns the ID
+        from that header (numeric IDs as ``int``, external IDs like
+        ``eid:CUST001`` as ``str``).
+
+        Example:
+            >>> customer_id = await rest_api.create_record(
+            ...     "customer",
+            ...     {"entityid": "Acme", "subsidiary": {"id": "1"}},
+            ... )
+
+        Documentation:
+            https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_1545141395.html
+        """
+        return await self.post(
+            f"/record/v1/{record_type}", json=record_data, **request_kw
+        )
 
     # TODO maybe break out params vs poping?
     async def suiteql(self, q: str, limit: int = 10, offset: int = 0, **request_kw):

--- a/netsuite/rest_api_base.py
+++ b/netsuite/rest_api_base.py
@@ -1,6 +1,7 @@
 import asyncio
 import functools
 import logging
+import re
 import time
 from functools import cached_property
 
@@ -57,6 +58,20 @@ class RestApiBase:
             raise NetsuiteAPIRequestError(resp.status_code, resp.text)
 
         if resp.status_code == 204:
+            # NetSuite responds 204 with a `Location` header on successful
+            # POST creates; the URL ends with the new record's ID. Surface
+            # it to callers so they don't have to crack the header
+            # themselves. Numeric IDs come back as `int`; external IDs
+            # (e.g. `eid:CUST001`) come back as `str`.
+            if method.upper() == "POST" and "location" in resp.headers:
+                location = resp.headers["location"]
+                match = re.search(r"/([^/]+)$", location)
+                if match:
+                    record_id = match.group(1)
+                    try:
+                        return int(record_id)
+                    except ValueError:
+                        return record_id
             return None
         else:
             try:

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -1,6 +1,7 @@
 import logging
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
+import httpx
 import pytest
 
 from netsuite import NetSuiteRestApi
@@ -9,6 +10,75 @@ from netsuite import NetSuiteRestApi
 def test_expected_hostname(dummy_config):
     rest_api = NetSuiteRestApi(dummy_config)
     assert rest_api.hostname == "123456-sb1.suitetalk.api.netsuite.com"
+
+
+def _location_response(location: str) -> Mock:
+    """Mock a NetSuite POST-create response: HTTP 204 with a Location header."""
+    resp = Mock(spec=httpx.Response)
+    resp.status_code = 204
+    resp.headers = {"location": location}
+    resp.text = ""
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_post_returns_numeric_record_id_from_location_header(dummy_config):
+    rest_api = NetSuiteRestApi(dummy_config)
+    rest_api._request_impl = AsyncMock(  # type: ignore[method-assign]
+        return_value=_location_response(
+            "https://123456-sb1.suitetalk.api.netsuite.com/services/rest/record/v1/customer/647"
+        )
+    )
+    result = await rest_api.post("/record/v1/customer", json={"entityid": "Acme"})
+    assert result == 647
+    assert isinstance(result, int)
+
+
+@pytest.mark.asyncio
+async def test_post_returns_string_external_id_from_location_header(dummy_config):
+    rest_api = NetSuiteRestApi(dummy_config)
+    rest_api._request_impl = AsyncMock(  # type: ignore[method-assign]
+        return_value=_location_response(
+            "https://123456-sb1.suitetalk.api.netsuite.com/services/rest/record/v1/customer/eid:CUST001"
+        )
+    )
+    result = await rest_api.post("/record/v1/customer", json={"entityid": "Acme"})
+    assert result == "eid:CUST001"
+    assert isinstance(result, str)
+
+
+@pytest.mark.asyncio
+async def test_post_returns_none_when_no_location_header(dummy_config):
+    """Some POST endpoints (e.g. SuiteQL) return 204 without a Location.
+    Those should still return None — the new behavior only kicks in for
+    record creates."""
+    rest_api = NetSuiteRestApi(dummy_config)
+    resp = Mock(spec=httpx.Response)
+    resp.status_code = 204
+    resp.headers = {}
+    resp.text = ""
+    rest_api._request_impl = AsyncMock(return_value=resp)  # type: ignore[method-assign]
+    assert await rest_api.post("/record/v1/customer", json={}) is None
+
+
+@pytest.mark.asyncio
+async def test_create_record_helper_posts_to_record_endpoint(dummy_config):
+    rest_api = NetSuiteRestApi(dummy_config)
+    rest_api._request_impl = AsyncMock(  # type: ignore[method-assign]
+        return_value=_location_response(
+            "https://123456-sb1.suitetalk.api.netsuite.com/services/rest/record/v1/customer/123"
+        )
+    )
+    result = await rest_api.create_record(
+        "customer",
+        {"entityid": "Acme", "subsidiary": {"id": "1"}},
+    )
+    assert result == 123
+    # Verify it routed through POST /record/v1/customer.
+    rest_api._request_impl.assert_awaited_once()
+    args, kwargs = rest_api._request_impl.await_args
+    assert args == ("POST", "/record/v1/customer")
+    assert kwargs["json"] == {"entityid": "Acme", "subsidiary": {"id": "1"}}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Imports [jacobsvante/netsuite#121](https://github.com/jacobsvante/netsuite/pull/121) (chrisperish).

NetSuite's REST API responds to a successful POST-create with **HTTP 204** plus a \`Location\` header pointing at the new record's URL. Until now this lib returned \`None\` on every 204, forcing callers to crack the header themselves or follow up with a search to find the just-created record's ID.

\`\`\`python
customer_id = await rest_api.create_record(
    "customer",
    {"entityid": "Acme", "subsidiary": {"id": "1"}},
)
# customer_id == 647 (int) — extracted from
# Location: .../services/rest/record/v1/customer/647
\`\`\`

Numeric IDs come back as \`int\`; external IDs like \`eid:CUST001\` come back as \`str\`.

## Cross-cutting note

The Location-extraction lives in \`RestApiBase._request\`, so it applies to **any** POST returning 204 with a Location header — including restlet POSTs. Restlets typically don't return Location headers, so existing restlet code is unaffected, but worth flagging.

POSTs returning 204 with **no** Location header (e.g. SuiteQL endpoints in some configurations) still return \`None\` — there's a regression test for that.

## Test plan
- [x] 4 new tests in \`tests/test_rest_api.py\`: numeric ID, external ID, no-Location-passthrough, \`create_record\` helper end-to-end
- [x] \`pytest -q\` — 187 passed
- [x] \`black\`/\`isort\`/\`flake8\`/\`mypy\` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)