### PR TITLE
ci(codecov): pass CODECOV_TOKEN to codecov-action

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -19,3 +19,4 @@ jobs:
       - uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

You added \`CODECOV_TOKEN\` as a repo secret. This wires it into the existing \`codecov/codecov-action@v5\` step in [\`.github/workflows/codecov.yml\`](.github/workflows/codecov.yml) so coverage uploads can authenticate.

\`\`\`yaml
- uses: codecov/codecov-action@v5
  with:
    files: ./coverage.xml
    token: \${{ secrets.CODECOV_TOKEN }}
\`\`\`

The action's \`name:\` field is optional — the existing \`uses:\` block is sufficient, just needed the \`token:\` line under \`with:\`.

## Test plan
- [x] Once merged, the \`codecov\` workflow on the next push to \`main\` will upload coverage to https://codecov.io/gh/vlouvet/netsuite — the README badge will start reporting real numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)