### PR TITLE
feat(odbc): add SuiteAnalytics Connect ODBC client (upstream #122, with revisions)

### DIFF
--- a/netsuite/__init__.py
+++ b/netsuite/__init__.py
@@ -1,6 +1,7 @@
 from . import constants  # noqa
 from .client import *  # noqa
 from .config import *  # noqa
+from .odbc import *  # noqa
 from .rest_api import *  # noqa
 from .restlet import *  # noqa
 from .soap_api import *  # noqa

--- a/netsuite/config.py
+++ b/netsuite/config.py
@@ -32,13 +32,18 @@ class TokenAuth(BaseModel):
 
 class UsernamePasswordAuth(BaseModel):
     """
-    This is a very old authentication method that is not recommended for use.
+    Username/password auth. Not recommended for SOAP/REST — those should
+    use `TokenAuth` (legacy OAuth 1.0a TBA) or
+    `OAuth2ClientCredentialsAuth`. This class is the only way to
+    authenticate to NetSuite's SuiteAnalytics Connect ODBC service.
 
-    However, it's the only way to access the netsuite.com (NOT netsuite2.com) data source via ODBC.
+    `role` is the NetSuite role's internal ID (or name) to assume on the
+    connection — required for ODBC, ignored elsewhere.
     """
 
     username: str
     password: str
+    role: t.Optional[t.Union[str, int]] = None
 
 
 class OAuth2ClientCredentialsAuth(BaseModel):
@@ -85,12 +90,21 @@ class Config(BaseModel):
 
     log_level: t.Optional[str] = None
 
-    # TODO ODBC is not yet fully supported, but this is the first step
+    # SuiteAnalytics Connect ODBC settings. `odbc_data_source` selects which
+    # NetSuite ODBC backend to talk to ("NetSuite2.com" is the modern
+    # SuiteAnalytics Connect; "NetSuite.com" is the legacy data source).
+    # `odbc_driver` is the platform-specific driver name registered with
+    # the local ODBC driver manager — overridable per OS.
     odbc_data_source: t.Literal["NetSuite.com", "NetSuite2.com"] = "NetSuite.com"
+    odbc_driver: str = "{NetSuite Drivers 64bit}"
 
     @property
     def is_token_auth(self) -> bool:
         return isinstance(self.auth, TokenAuth)
+
+    @property
+    def is_password_auth(self) -> bool:
+        return isinstance(self.auth, UsernamePasswordAuth)
 
     @property
     def is_oauth2_auth(self) -> bool:
@@ -141,6 +155,11 @@ class Config(BaseModel):
         - `NETSUITE_TOKEN_SECRET`: The token secret for OAuth.
         - `NETSUITE_USERNAME`: The username for login auth (only for odbc).
         - `NETSUITE_PASSWORD`: The password for login auth (only for odbc).
+        - `NETSUITE_ROLE`: The NetSuite role for ODBC connections.
+        - `NETSUITE_ODBC_DRIVER`: ODBC driver name registered with the local
+          ODBC driver manager (defaults to `{NetSuite Drivers 64bit}`).
+        - `NETSUITE_ODBC_DATA_SOURCE`: NetSuite ODBC data source
+          (`NetSuite.com` or `NetSuite2.com`).
         - `NETSUITE_LOG_LEVEL`: log level for NetSuite debugging
 
         Returns a dictionary of available config options.
@@ -155,6 +174,9 @@ class Config(BaseModel):
             "token_secret",
             "username",
             "password",
+            "role",
+            "odbc_driver",
+            "odbc_data_source",
             "log_level",
         ]
         prefix = "NETSUITE_"

--- a/netsuite/odbc.py
+++ b/netsuite/odbc.py
@@ -1,0 +1,106 @@
+"""SuiteAnalytics Connect ODBC client.
+
+NetSuite exposes a relational view of an account's data through
+SuiteAnalytics Connect, which speaks ODBC. This module wraps `pyodbc`
+to make connecting to it from Python a one-liner once the platform
+ODBC driver is installed.
+
+Imports the implementation from upstream PR jacobsvante/netsuite#122
+(tonymorello), with adjustments for Python 3.9 compatibility and to
+keep the existing UsernamePasswordAuth deprecation language.
+"""
+
+import typing as t
+
+from .config import Config, UsernamePasswordAuth
+
+# `pyodbc` is an optional dependency installed via the `odbc` extra. We
+# lazy-import it so the rest of the package still imports cleanly when
+# the extra isn't installed; only callers that actually instantiate
+# `NetSuiteODBC` will need it.
+try:
+    import pyodbc as _pyodbc
+
+    PYODBC_INSTALLED = True
+except ImportError:
+    _pyodbc = None  # type: ignore[assignment]
+    PYODBC_INSTALLED = False
+
+__all__ = ("NetSuiteODBC", "PYODBC_INSTALLED")
+
+
+class NetSuiteODBC:
+    """A connection helper for NetSuite's SuiteAnalytics Connect ODBC service.
+
+    Uses `Config.auth` (must be `UsernamePasswordAuth`) and
+    `Config.odbc_data_source` / `Config.odbc_driver` to assemble a
+    connection string, then exposes `connect()`, `execute()`, and
+    `query()` for common operations.
+    """
+
+    def __init__(self, config: Config):
+        if not PYODBC_INSTALLED:
+            raise RuntimeError(
+                "pyodbc is required for ODBC connections. "
+                "Install with `pip install 'netsuite[odbc] @ "
+                "git+https://github.com/vlouvet/netsuite.git'`."
+            )
+        if not config.is_password_auth:
+            raise RuntimeError(
+                "ODBC connections require UsernamePasswordAuth. "
+                "TokenAuth and OAuth 2.0 are not supported by "
+                "SuiteAnalytics Connect."
+            )
+        self._config = config
+
+    @property
+    def hostname(self) -> str:
+        return f"{self._config.account_slugified}.connect.api.netsuite.com"
+
+    @property
+    def connection_string(self) -> str:
+        auth = self._config.auth
+        # Sanity-checked in __init__ but mypy needs the narrow.
+        assert isinstance(auth, UsernamePasswordAuth)
+        role_part = f"RoleID={auth.role}" if auth.role is not None else ""
+        return ";".join(
+            part
+            for part in (
+                f"DRIVER={self._config.odbc_driver}",
+                f"Host={self.hostname}",
+                "Port=1708",
+                "Encrypted=1",
+                "AllowSinglePacketLogout=1",
+                "Truststore=system",
+                f"ServerDataSource={self._config.odbc_data_source}",
+                f"UID={auth.username}",
+                f"PWD={auth.password}",
+                (
+                    f"CustomProperties=AccountID={self._config.account};" f"{role_part}"
+                ).rstrip(";"),
+            )
+            if part
+        )
+
+    def connect(self):
+        """Open a new pyodbc connection. Caller is responsible for closing."""
+        return _pyodbc.connect(self.connection_string)
+
+    def execute(self, sql: str):
+        """Execute a SQL statement and return the pyodbc cursor.
+
+        Note: the connection is closed when this returns. For workloads
+        where you need to iterate cursor rows lazily, use `connect()`
+        directly and manage the connection yourself.
+        """
+        with self.connect() as connection:
+            cursor = connection.cursor()
+            return cursor.execute(sql)
+
+    def query(self, sql: str) -> t.List[t.Dict[str, t.Any]]:
+        """Execute a SQL statement and return all rows as a list of dicts."""
+        with self.connect() as connection:
+            cursor = connection.cursor()
+            response = cursor.execute(sql)
+            headers = [col[0] for col in response.description]
+            return [dict(zip(headers, row)) for row in response.fetchall()]

--- a/tests/test_odbc.py
+++ b/tests/test_odbc.py
@@ -1,4 +1,21 @@
-# TODO need more expanded tests here
+"""Tests for NetSuite SuiteAnalytics Connect ODBC support.
+
+The core of `NetSuiteODBC` is connection-string assembly; the runtime
+calls (`connect`, `execute`, `query`) just delegate to pyodbc. We test
+the assembly directly and use mocking for the delegation paths.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from netsuite import NetSuiteODBC
+from netsuite.config import Config, UsernamePasswordAuth
+from netsuite.odbc import PYODBC_INSTALLED
+
+# ---------------------------------------------------------------------------
+# Existing config-level tests (kept from before)
+# ---------------------------------------------------------------------------
 
 
 def test_tba(dummy_config):
@@ -23,3 +40,210 @@ def test_username_auth(dummy_username_password_config):
 
     assert config.auth.username == "username"
     assert not config.is_token_auth
+    assert config.is_password_auth
+
+
+# ---------------------------------------------------------------------------
+# Config additions
+# ---------------------------------------------------------------------------
+
+
+def test_username_auth_role_optional():
+    auth = UsernamePasswordAuth(username="u", password="p")
+    assert auth.role is None
+
+
+def test_username_auth_role_can_be_int_or_str():
+    assert UsernamePasswordAuth(username="u", password="p", role=3).role == 3
+    assert (
+        UsernamePasswordAuth(username="u", password="p", role="admin").role == "admin"
+    )
+
+
+def test_default_odbc_driver():
+    config = Config(account="123", auth={"username": "u", "password": "p"})
+    assert config.odbc_driver == "{NetSuite Drivers 64bit}"
+
+
+def test_default_odbc_data_source():
+    config = Config(account="123", auth={"username": "u", "password": "p"})
+    assert config.odbc_data_source == "NetSuite.com"
+
+
+def test_odbc_driver_overridable():
+    config = Config(
+        account="123",
+        auth={"username": "u", "password": "p"},
+        odbc_driver="MyCustomDriver",
+    )
+    assert config.odbc_driver == "MyCustomDriver"
+
+
+def test_odbc_data_source_rejects_invalid_value():
+    """`odbc_data_source` is a Literal — Pydantic should reject other values."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        Config(
+            account="123",
+            auth={"username": "u", "password": "p"},
+            odbc_data_source="bogus",  # type: ignore[arg-type]
+        )
+
+
+# ---------------------------------------------------------------------------
+# is_password_auth dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_token_config_is_not_password_auth(dummy_config):
+    assert not dummy_config.is_password_auth
+
+
+def test_password_config_is_not_token_auth(dummy_username_password_config):
+    assert not dummy_username_password_config.is_token_auth
+    assert dummy_username_password_config.is_password_auth
+
+
+# ---------------------------------------------------------------------------
+# NetSuiteODBC initialization
+# ---------------------------------------------------------------------------
+
+
+pytestmark_pyodbc = pytest.mark.skipif(not PYODBC_INSTALLED, reason="Requires pyodbc")
+
+
+def test_odbc_rejects_token_auth(dummy_config):
+    """Token auth makes no sense for ODBC — surface a clear error."""
+    if not PYODBC_INSTALLED:
+        pytest.skip("Requires pyodbc")
+    with pytest.raises(RuntimeError, match="UsernamePasswordAuth"):
+        NetSuiteODBC(dummy_config)
+
+
+def test_odbc_init_accepts_username_password(dummy_username_password_config):
+    if not PYODBC_INSTALLED:
+        pytest.skip("Requires pyodbc")
+    odbc = NetSuiteODBC(dummy_username_password_config)
+    assert odbc._config is dummy_username_password_config
+
+
+def test_odbc_hostname_uses_account_subdomain(dummy_username_password_config):
+    if not PYODBC_INSTALLED:
+        pytest.skip("Requires pyodbc")
+    odbc = NetSuiteODBC(dummy_username_password_config)
+    assert odbc.hostname == "123456-sb1.connect.api.netsuite.com"
+
+
+# ---------------------------------------------------------------------------
+# Connection-string assembly
+# ---------------------------------------------------------------------------
+
+
+def _odbc_with_role(role):
+    config = Config(
+        account="123_SB1",
+        auth={"username": "u", "password": "p", "role": role},
+    )
+    if not PYODBC_INSTALLED:
+        return None
+    return NetSuiteODBC(config)
+
+
+def test_connection_string_includes_all_fields(dummy_username_password_config):
+    if not PYODBC_INSTALLED:
+        pytest.skip("Requires pyodbc")
+    odbc = NetSuiteODBC(dummy_username_password_config)
+    cs = odbc.connection_string
+    assert "DRIVER={NetSuite Drivers 64bit}" in cs
+    assert "Host=123456-sb1.connect.api.netsuite.com" in cs
+    assert "Port=1708" in cs
+    assert "UID=username" in cs
+    assert "PWD=password" in cs
+    assert "ServerDataSource=NetSuite.com" in cs
+    assert "AccountID=123456_SB1" in cs
+
+
+def test_connection_string_includes_role_when_set():
+    if not PYODBC_INSTALLED:
+        pytest.skip("Requires pyodbc")
+    odbc = _odbc_with_role(role=3)
+    assert "RoleID=3" in odbc.connection_string
+
+
+def test_connection_string_omits_role_when_unset(dummy_username_password_config):
+    if not PYODBC_INSTALLED:
+        pytest.skip("Requires pyodbc")
+    odbc = NetSuiteODBC(dummy_username_password_config)
+    assert "RoleID=" not in odbc.connection_string
+
+
+def test_connection_string_uses_custom_driver():
+    if not PYODBC_INSTALLED:
+        pytest.skip("Requires pyodbc")
+    config = Config(
+        account="123",
+        auth={"username": "u", "password": "p"},
+        odbc_driver="MyDriver",
+    )
+    odbc = NetSuiteODBC(config)
+    assert "DRIVER=MyDriver" in odbc.connection_string
+
+
+# ---------------------------------------------------------------------------
+# query() / execute() delegation. We mock pyodbc.connect so no driver is
+# required to exercise these.
+# ---------------------------------------------------------------------------
+
+
+def test_query_returns_list_of_dicts(dummy_username_password_config):
+    if not PYODBC_INSTALLED:
+        pytest.skip("Requires pyodbc")
+    odbc = NetSuiteODBC(dummy_username_password_config)
+
+    mock_cursor = MagicMock()
+    mock_cursor.description = [("id",), ("name",)]
+    mock_cursor.fetchall.return_value = [(1, "alice"), (2, "bob")]
+    mock_cursor.execute.return_value = mock_cursor
+
+    mock_conn = MagicMock()
+    mock_conn.__enter__.return_value = mock_conn
+    mock_conn.__exit__.return_value = False
+    mock_conn.cursor.return_value = mock_cursor
+
+    with patch("netsuite.odbc._pyodbc.connect", return_value=mock_conn) as mock_connect:
+        rows = odbc.query("SELECT id, name FROM customer")
+
+    mock_connect.assert_called_once_with(odbc.connection_string)
+    mock_cursor.execute.assert_called_once_with("SELECT id, name FROM customer")
+    assert rows == [{"id": 1, "name": "alice"}, {"id": 2, "name": "bob"}]
+
+
+def test_execute_passes_sql_through(dummy_username_password_config):
+    if not PYODBC_INSTALLED:
+        pytest.skip("Requires pyodbc")
+    odbc = NetSuiteODBC(dummy_username_password_config)
+
+    mock_cursor = MagicMock()
+    mock_conn = MagicMock()
+    mock_conn.__enter__.return_value = mock_conn
+    mock_conn.__exit__.return_value = False
+    mock_conn.cursor.return_value = mock_cursor
+
+    with patch("netsuite.odbc._pyodbc.connect", return_value=mock_conn):
+        odbc.execute("UPDATE customer SET active=1")
+
+    mock_cursor.execute.assert_called_once_with("UPDATE customer SET active=1")
+
+
+# ---------------------------------------------------------------------------
+# Missing-pyodbc behavior
+# ---------------------------------------------------------------------------
+
+
+def test_init_raises_when_pyodbc_not_installed(dummy_username_password_config):
+    """If `pyodbc` is unavailable, instantiating NetSuiteODBC must fail
+    with a message pointing the user at the `odbc` extra."""
+    with patch("netsuite.odbc.PYODBC_INSTALLED", False):
+        with pytest.raises(RuntimeError, match="odbc"):
+            NetSuiteODBC(dummy_username_password_config)


### PR DESCRIPTION
## Summary

Imports [jacobsvante/netsuite#122](https://github.com/jacobsvante/netsuite/pull/122) (tonymorello) — adds a working ODBC client for NetSuite's SuiteAnalytics Connect.

\`\`\`python
from netsuite import Config, NetSuiteODBC

config = Config(
    account="123456_SB1",
    auth={"username": "u", "password": "p", "role": 3},
    odbc_data_source="NetSuite2.com",
)
odbc = NetSuiteODBC(config)
rows = odbc.query("SELECT id, entityid FROM customer WHERE isinactive = 'F'")
# -> [{"id": 1, "entityid": "Acme"}, ...]
\`\`\`

## Three deviations from upstream

1. **Type annotation**: \`Optional[Union[str, int]]\` instead of upstream's \`str | int\`. The PEP 604 syntax requires Python 3.10+, and our \`pyproject.toml\` floor is \`python = ">=3.9"\`.
2. **Auth deprecation language preserved**: upstream removed the \`UsernamePasswordAuth\` docstring that warns the auth class is legacy. Kept and expanded it — ODBC is now flagged as the one place this auth is required.
3. **Skipped the \`[tool.poetry]\` -> \`[project]\` restructure**: upstream PEP-621-ifies pyproject.toml in the same change. That conflicts with our existing layout (and with the OAuth 2.0 deps added in #11). Worth doing as a separate cleanup, not bundled with the feature.

## What's added

| File | Change |
|---|---|
| \`netsuite/odbc.py\` (new) | \`NetSuiteODBC\` with \`connect\` / \`execute\` / \`query\`. Lazy-imports pyodbc so the package still loads cleanly without the \`odbc\` extra. |
| \`netsuite/config.py\` | \`Config.odbc_driver\` (default \`{NetSuite Drivers 64bit}\`), \`Config.is_password_auth\` property, \`UsernamePasswordAuth.role\`. |
| \`Config.from_env\` | Picks up \`NETSUITE_ROLE\`, \`NETSUITE_ODBC_DRIVER\`, \`NETSUITE_ODBC_DATA_SOURCE\`. |
| \`netsuite/__init__.py\` | Re-exports \`NetSuiteODBC\` from the top level. |
| \`tests/test_odbc.py\` | 18 new tests covering connection-string assembly, role inclusion/omission, custom driver, \`is_password_auth\` dispatch, \`query\`/\`execute\` against mocked \`pyodbc.connect\`. Pyodbc-touching tests skip cleanly when the driver shared library isn't loadable (e.g. macOS without unixODBC) — they run on CI. |

## Test plan
- [x] \`pytest -q\` — 192 passed, 9 skipped (pyodbc-dependent tests, run on CI)
- [x] \`black --check\`, \`isort --check\`, \`flake8\`, \`mypy --ignore-missing-imports .\` — clean
- [ ] Live smoke against a SuiteAnalytics Connect instance is left to reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)