### PR TITLE
build(deps-dev): black ~24 -> ~25

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ orjson = ["orjson"]
 all = ["zeep", "ipython", "orjson", "odbc"]
 
 [tool.poetry.dev-dependencies]
-black = "~24"
+black = "~25"
 flake8 = "~7"
 isort = "~6"
 mkdocs-material = "~9"


### PR DESCRIPTION
## Summary

Imports [jacobsvante/netsuite#109](https://github.com/jacobsvante/netsuite/pull/109) (dependabot).

Black 25 ships the 2025 stable style — PEP 639 license metadata, trailing-comma normalization on typed parameters, etc. None of those rules trigger on the current codebase, so this PR is just the version pin: \`black --check .\` after the bump is clean with zero reformat hunks.

If at some point Black 25's style does fire on a future change, that diff stays scoped to the PR introducing the new code rather than being a one-time mass reformat here.

## Test plan
- [x] \`black --check .\` (with black 25.12.0 installed) — \"45 files would be left unchanged\"
- [x] \`pytest -q\` — 183 passed
- [x] \`isort\`/\`flake8\`/\`mypy\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)