### PR TITLE
chore(pyproject): migrate to PEP 621 layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,15 @@
-[tool.poetry]
+[project]
 name = "netsuite"
 version = "0.12.0"
 description = "Make async requests to NetSuite SuiteTalk SOAP/REST Web Services and Restlets"
-authors = [
-    "Jacob Magnusson <m@jacobian.se>",
-    "Mike Bianco <mike@mikebian.co>",
-    "Vicente Louvet III <louvetvicente@gmail.com>",
-]
-license = "MIT"
 readme = "README.md"
-homepage = "https://github.com/vlouvet/netsuite"
-repository = "https://github.com/vlouvet/netsuite"
+license = "MIT"
+requires-python = ">=3.9"
+authors = [
+    { name = "Jacob Magnusson", email = "m@jacobian.se" },
+    { name = "Mike Bianco", email = "mike@mikebian.co" },
+    { name = "Vicente Louvet III", email = "louvetvicente@gmail.com" },
+]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Web Environment",
@@ -18,37 +17,48 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
+dependencies = [
+    "authlib>=1,<3",
+    # As per httpx recommendation we lock to a fixed minor range until 1.0.
+    "httpx>=0.25,<0.29",
+    # Used directly by netsuite/oauth2.py for JWT signing. Newer authlib
+    # pulls this in transitively but older authlib in our >=1,<3 range
+    # does not — declare it explicitly so CI installs are deterministic.
+    "joserfc>=1,<2",
+    "oauthlib>=3,<4",
+    "pydantic>=2.4.2,<3",
 ]
 
-[tool.poetry.dependencies]
-python = ">=3.9"
-authlib = ">=1,<3"
-# As per httpx recommendation we will lock to a fixed minor version until 1.0 is released
-httpx = ">=0.25,<0.29"
-# Used directly by netsuite/oauth2.py for JWT signing. Newer authlib pulls
-# this in transitively, but older authlib in our `>=1,<3` range does not,
-# so declare it explicitly to keep CI installs deterministic.
-joserfc = ">=1,<2"
-pydantic = "^2.4.2"
-orjson = { version = "~3", optional = true }
-ipython = { version = "~8", optional = true, python = "^3.9" }
-zeep = { version = "~4", optional = true, extras = ["async"] }
-pyodbc = { version = "^5.0.1", optional = true }
-oauthlib = "~3"
+[project.optional-dependencies]
+odbc = ["pyodbc>=5.0.1,<6"]
+soap_api = ["zeep[async]>=4,<5"]
+cli = ["ipython>=8,<9"]
+orjson = ["orjson>=3,<4"]
+all = [
+    "pyodbc>=5.0.1,<6",
+    "zeep[async]>=4,<5",
+    "ipython>=8,<9",
+    "orjson>=3,<4",
+]
 
-[tool.poetry.extras]
-odbc = ["pyodbc"]
-soap_api = ["zeep"]
-cli = ["ipython"]
-orjson = ["orjson"]
-# TODO doesn't --all-extras solve this for us?
-all = ["zeep", "ipython", "orjson", "odbc"]
+[project.scripts]
+netsuite = "netsuite.cli:main"
 
-[tool.poetry.dev-dependencies]
+[project.urls]
+Homepage = "https://github.com/vlouvet/netsuite"
+Repository = "https://github.com/vlouvet/netsuite"
+
+[tool.poetry]
+# Poetry-specific block. Project metadata lives in [project] above; this
+# section only carries the bits Poetry needs that PEP 621 doesn't cover.
+
+[tool.poetry.group.dev.dependencies]
 black = "~24"
 flake8 = "~7"
 isort = "~6"
@@ -60,16 +70,13 @@ pytest-cov = "~5"
 types-setuptools = "^75.8.2"
 types-requests = "^2.27.30"
 
-[tool.poetry.scripts]
-netsuite = 'netsuite.cli:main'
-
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=2"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 88
-target-version = ["py37", "py38", "py39", "py310"]
+target-version = ["py39", "py310", "py311", "py312", "py313"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
## Summary

Modernizes \`pyproject.toml\` from Poetry-only metadata to the standardized **PEP 621** layout. This is the cleanup PR I left as a TODO when importing #17 (ODBC) — upstream's [#122](https://github.com/jacobsvante/netsuite/pull/122) bundled this restructure with the ODBC feature, and bundling them made the diff hard to review. Splitting the format change out makes both reviewable on their own merits.

### Format swap

| Before | After |
|---|---|
| \`[tool.poetry]\` (metadata) | \`[project]\` |
| \`[tool.poetry.dependencies]\` | \`[project.dependencies]\` (PEP 508 strings) |
| \`[tool.poetry.extras]\` | \`[project.optional-dependencies]\` |
| \`[tool.poetry.scripts]\` | \`[project.scripts]\` |
| \`homepage\` / \`repository\` keys | \`[project.urls]\` |
| \`[tool.poetry.dev-dependencies]\` (deprecated) | \`[tool.poetry.group.dev.dependencies]\` (modern Poetry form) |

### Why bother

Other tooling that reads PEP 621 metadata — \`uv\`, \`pipx\`, \`hatch\`, \`build\`, \`flit\`, plain \`pip install\` against the source — can now work with this project without a Poetry-specific shim. Poetry itself reads PEP 621 metadata as authoritative when it's present, so the user-facing \`poetry install\` flow is unchanged.

### Numeric constraints preserved exactly

PEP 508 doesn't have Poetry's \`^\` / \`~\` shortcuts, so I expanded each one to its equivalent range:

| Poetry | PEP 508 |
|---|---|
| \`^2.4.2\` | \`>=2.4.2,<3\` (pydantic) |
| \`~3\` | \`>=3,<4\` (oauthlib, orjson) |
| \`~4\` | \`>=4,<5\` (zeep) |
| \`~8\` | \`>=8,<9\` (ipython) |
| \`^5.0.1\` | \`>=5.0.1,<6\` (pyodbc) |

### Things I deliberately didn't change

- **Version**: still \`0.12.0\`. This is infrastructure, not a release.
- **\`license = \"MIT\"\`**: kept as a SPDX expression string. Newer setuptools/poetry-core surface it as \`License-Expression: MIT\` in installed metadata (PEP 639) — that's correct.
- **\`all\` extra**: enumerated explicitly. PEP 621 \`optional-dependencies\` doesn't reference other extras by name, so the previous shorthand \`all = [\"zeep\", \"ipython\", \"orjson\", \"odbc\"]\` had to be expanded.
- **Test files**: untouched. Black 24 (the version pinned in this PR's dev-deps) is happy with the current formatting. PR #18's black 25 bump will handle any new-style reformatting.

### Build system bump

\`requires = [\"poetry-core>=2\"]\` because poetry-core needs to be 2+ to read \`[project]\` as the metadata source. Older poetry-core (1.x) would happily ignore the new layout and emit a wheel with empty metadata.

## Test plan

- [x] \`pip install -e \".[all]\"\` against the new layout succeeds
- [x] \`pip show netsuite\` confirms the right authors, URLs, classifiers, console script, and SPDX license make it into the wheel metadata
- [x] \`pytest -q\` — 183 passed
- [x] \`isort --check\`, \`flake8\`, \`mypy --ignore-missing-imports .\` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)