### PR TITLE
fix(soap): align deprecation wording with official 2026.1 removal plans

### DIFF
--- a/netsuite/oauth2.py
+++ b/netsuite/oauth2.py
@@ -1,7 +1,9 @@
 """OAuth 2.0 support for NetSuite.
 
-NetSuite is sunsetting SOAP Web Services in the 2027.1 release. The
-recommended path forward is the REST API authenticated via OAuth 2.0.
+NetSuite is gradually removing SOAP Web Services (2025.2 is the last
+planned SOAP endpoint, with older endpoints losing support over the
+following releases). The recommended path forward is the REST API
+authenticated via OAuth 2.0.
 This module implements the two flows that matter for a backend library:
 
 * **Client Credentials with JWT Bearer Assertion** (RFC 7523 — *machine-

--- a/netsuite/soap_api/client.py
+++ b/netsuite/soap_api/client.py
@@ -17,10 +17,13 @@ __all__ = ("NetSuiteSoapApi",)
 
 
 SOAP_DEPRECATION_MESSAGE = (
-    "NetSuite has announced that SOAP Web Services will be removed in the "
-    "2027.1 release. New integrations should use the REST API with OAuth 2.0 "
-    "(see `netsuite.OAuth2ClientCredentialsAuth`); existing SOAP integrations "
-    "should plan a migration before 2027.1."
+    "NetSuite has announced that SOAP Web Services are being gradually "
+    "removed. The 2025.2 endpoint is the last planned SOAP endpoint, and "
+    "older endpoints lose support over the following releases. New "
+    "integrations should use the REST API with OAuth 2.0 (see "
+    "`netsuite.OAuth2ClientCredentialsAuth`); existing SOAP integrations "
+    "should plan a migration. See NetSuite's SOAP Removal Plans FAQ for the "
+    "endpoint support timeline."
 )
 
 

--- a/tests/test_soap_api_deprecation.py
+++ b/tests/test_soap_api_deprecation.py
@@ -1,6 +1,6 @@
 """Verify NetSuiteSoapApi emits a DeprecationWarning pointing users at
-OAuth 2.0. NetSuite plans to remove SOAP Web Services in the 2027.1
-release, and the warning is the user-facing nudge to migrate."""
+OAuth 2.0. NetSuite is gradually removing SOAP Web Services (2025.2 is the
+last planned endpoint), and the warning is the user-facing nudge to migrate."""
 
 import warnings
 
@@ -21,7 +21,7 @@ def test_soap_api_init_emits_deprecation_warning(dummy_config):
         w for w in caught if issubclass(w.category, DeprecationWarning)
     ]
     assert len(deprecation_warnings) == 1
-    assert "2027.1" in str(deprecation_warnings[0].message)
+    assert "2025.2" in str(deprecation_warnings[0].message)
     assert "OAuth 2.0" in str(deprecation_warnings[0].message)
 
 
@@ -30,4 +30,4 @@ def test_soap_deprecation_message_mentions_replacement(dummy_config):
     have a concrete next step, not just a generic warning."""
     assert "OAuth2ClientCredentialsAuth" in SOAP_DEPRECATION_MESSAGE
     assert "REST API" in SOAP_DEPRECATION_MESSAGE
-    assert "2027.1" in SOAP_DEPRECATION_MESSAGE
+    assert "2025.2" in SOAP_DEPRECATION_MESSAGE


### PR DESCRIPTION
The deprecation warning and OAuth2 module docstring asserted SOAP Web Services 'will be removed in the 2027.1 release.' The NetSuite 2026.1 SuiteTalk release notes make no such hard-date claim: removal is gradual, 2025.2 is the last *planned* SOAP endpoint, and older endpoints degrade to unsupported over subsequent releases (later endpoints only released as needed).

Soften the message and docstring to match the official wording and point at the SOAP Removal Plans FAQ. The 'NetSuite has announced that SOAP Web Services' prefix is preserved so the pyproject filterwarnings entry still matches. Update test_soap_api_deprecation to assert 2025.2 instead of the removed 2027.1 date.