### PR TITLE
chore(gitignore): ignore local /specs/ scratch folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 /.pytest_cache
 /poetry.lock
 .DS_Store
+/specs/


### PR DESCRIPTION
The specs/ folder holds local reference material (NetSuite release-note PDFs, scratch notes) that should not be tracked.