### PR TITLE
feat(rest): add 2026.1 REST web services operation helpers

### DIFF
--- a/netsuite/rest_api.py
+++ b/netsuite/rest_api.py
@@ -1,14 +1,26 @@
 import logging
 import re
 from functools import cached_property
-from typing import Any, AsyncIterator, Dict, Optional, Sequence
+from typing import Any, AsyncIterator, Dict, Optional, Sequence, Union
 
-from . import rest_api_base
+from . import json, rest_api_base
 from .config import Config
+from .exceptions import NetsuiteAPIRequestError
 
 logger = logging.getLogger(__name__)
 
 __all__ = ("NetSuiteRestApi",)
+
+# Custom media types introduced for the 2026.1 REST web services
+# operations. Batch uses a `collection` content type; create-form and
+# selectOptions select their behaviour through the `Accept` header.
+_COLLECTION_MEDIA_TYPE = "application/vnd.oracle.resource+json; type=collection"
+_CREATE_FORM_MEDIA_TYPE = "application/vnd.oracle.resource+json; type=create-form"
+_SELECT_OPTIONS_MEDIA_TYPE = "application/vnd.oracle.resource+json; type=select-options"
+
+# Batch add/update/upsert verbs (GET/DELETE batches go through the normal
+# get()/delete() with an `ids` param instead).
+_BATCH_METHODS = ("POST", "PATCH", "PUT")
 
 
 def _next_link(suiteql_response: Dict[str, Any]) -> Optional[str]:
@@ -231,6 +243,211 @@ class NetSuiteRestApi(rest_api_base.RestApiBase):
             params=params,
             **request_kw,
         )
+
+    async def attach(
+        self,
+        record_type: str,
+        record_id: str,
+        target_type: str,
+        target_id: str,
+        *,
+        role: Optional[Dict[str, Any]] = None,
+        **request_kw,
+    ):
+        """
+        Attach one record instance to another, defining a relationship
+        between them (new in NetSuite 2026.1 REST web services).
+
+        `record_type`/`record_id` identify the record being attached *to*;
+        `target_type`/`target_id` identify the record being attached. Both
+        IDs may be internal IDs or external IDs in `eid:VALUE` form.
+
+        NetSuite currently supports attaching contact and file records only.
+        When attaching a contact you may pass `role` (e.g. `{"id": "-10"}`
+        or `{"externalId": "family"}`); otherwise the request body is empty.
+
+        Returns `None` (NetSuite responds with HTTP 204 No Content).
+
+        https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/article_0113084334.html
+        """
+        json_body = request_kw.pop("json", {})
+        if role is not None:
+            json_body = {"role": role, **json_body}
+        return await self._request(
+            "POST",
+            f"/record/v1/{record_type}/{record_id}/!attach/{target_type}/{target_id}",
+            json=json_body,
+            **request_kw,
+        )
+
+    async def detach(
+        self,
+        record_type: str,
+        record_id: str,
+        target_type: str,
+        target_id: str,
+        **request_kw,
+    ):
+        """
+        Remove the relationship between two record instances (the inverse of
+        `attach`). IDs may be internal IDs or `eid:VALUE` external IDs.
+
+        Returns `None` (HTTP 204 No Content).
+
+        https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/article_0113084334.html
+        """
+        return await self._request(
+            "POST",
+            f"/record/v1/{record_type}/{record_id}/!detach/{target_type}/{target_id}",
+            **request_kw,
+        )
+
+    async def create_form(
+        self,
+        record_type: str,
+        record_id: str,
+        target_type: str,
+        *,
+        body: Optional[Dict[str, Any]] = None,
+        **request_kw,
+    ):
+        """
+        Run the create-form (transform) operation: load a target record with
+        its fields prepopulated from a related source record, without
+        submitting it (new in NetSuite 2026.1 REST web services).
+
+        For example, transform a sales order into an item fulfillment to see
+        every default field and default line ID before you POST the new
+        record. Pass field overrides in `body`; the operation supports the
+        `expand`, `expandSubResources` and `fields` query params via
+        `params`.
+
+        Returns the prepopulated record as a dict.
+
+        https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/article_1217103046.html
+        """
+        headers = {
+            "Accept": _CREATE_FORM_MEDIA_TYPE,
+            **request_kw.pop("headers", {}),
+        }
+        return await self._request(
+            "POST",
+            f"/record/v1/{record_type}/{record_id}/!transform/{target_type}",
+            headers=headers,
+            json=body if body is not None else {},
+            **request_kw,
+        )
+
+    async def select_options(
+        self,
+        record_type: str,
+        fields: Union[str, Sequence[str]],
+        *,
+        record_id: Optional[str] = None,
+        body: Optional[Dict[str, Any]] = None,
+        **request_kw,
+    ):
+        """
+        Retrieve the valid select options for one or more fields on a record
+        (new in NetSuite 2026.1 REST web services).
+
+        Pass a single field name or a sequence of them in `fields` (sublist
+        fields use dotted names, e.g. `line.dueToFromSubsidiary`). Omit
+        `record_id` to get the options on a *new* record instance (issued as
+        a POST); pass `record_id` to query an *existing* instance (issued as
+        a PATCH). When the options depend on other field values, supply those
+        in `body` (e.g. `{"subsidiary": {"id": 1}}`).
+
+        Returns the response dict, with a `_selectOptions` block per requested
+        field (each itself paginated: `items`/`count`/`hasMore`/
+        `totalResults`).
+
+        https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/article_0115100241.html
+        """
+        if isinstance(fields, str):
+            fields = [fields]
+        headers = {
+            "Accept": _SELECT_OPTIONS_MEDIA_TYPE,
+            **request_kw.pop("headers", {}),
+        }
+        params = {"fields": ",".join(fields), **request_kw.pop("params", {})}
+        if record_id is None:
+            method, subpath = "POST", f"/record/v1/{record_type}"
+        else:
+            method, subpath = "PATCH", f"/record/v1/{record_type}/{record_id}"
+        return await self._request(
+            method,
+            subpath,
+            headers=headers,
+            params=params,
+            json=body if body is not None else {},
+            **request_kw,
+        )
+
+    async def batch(
+        self,
+        record_type: str,
+        items: Sequence[Dict[str, Any]],
+        *,
+        method: str = "POST",
+        idempotency_key: Optional[str] = None,
+        **request_kw,
+    ):
+        """
+        Add, update, or upsert up to 100 instances of a single record type in
+        one asynchronous request (new in NetSuite 2026.1 REST web services).
+
+        `method` is POST (create), PUT (upsert), or PATCH (update). Each item
+        in `items` is a record body; PATCH/PUT items must carry an `id` or
+        `externalId`. Pass `idempotency_key` to set the
+        `X-NetSuite-idempotency-key` header.
+
+        NetSuite processes the batch asynchronously, so this returns a dict
+        with the HTTP `status_code`, the `location` URL of the async job
+        (poll it with `get()`), and any response `body`. Unlike the other
+        helpers it talks to the lower-level request layer directly, because
+        the async job URL is only exposed in the `Location` response header,
+        which the JSON helpers discard.
+
+        For batch reads or deletes, use `get()`/`delete()` on the collection
+        endpoint with an `ids` param instead.
+
+        https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/article_0127092747.html
+        """
+        method = method.upper()
+        if method not in _BATCH_METHODS:
+            raise ValueError(
+                f"batch() method must be one of {_BATCH_METHODS}, got "
+                f"{method!r}. For batch reads/deletes use get()/delete() with "
+                "an `ids` param."
+            )
+        headers = {
+            "Prefer": "respond-async",
+            "Content-Type": _COLLECTION_MEDIA_TYPE,
+            **request_kw.pop("headers", {}),
+        }
+        if idempotency_key is not None:
+            headers.setdefault("X-NetSuite-idempotency-key", idempotency_key)
+        resp = await self._request_impl(
+            method,
+            f"/record/v1/{record_type}",
+            headers=headers,
+            json={"items": list(items), **request_kw.pop("json", {})},
+            **request_kw,
+        )
+        if resp.status_code < 200 or resp.status_code > 299:
+            raise NetsuiteAPIRequestError(resp.status_code, resp.text)
+        body = None
+        if resp.text:
+            try:
+                body = json.loads(resp.text)
+            except Exception:
+                body = None
+        return {
+            "status_code": resp.status_code,
+            "location": resp.headers.get("Location"),
+            "body": body,
+        }
 
     def _make_hostname(self):
         return f"{self._config.account_slugified}.suitetalk.api.netsuite.com"

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -1,9 +1,11 @@
 import logging
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
 from netsuite import NetSuiteRestApi
+from netsuite.exceptions import NetsuiteAPIRequestError
 
 
 def test_expected_hostname(dummy_config):
@@ -129,3 +131,148 @@ async def test_suiteql_order_by_detection_ignores_substrings(dummy_config, caplo
     with caplog.at_level(logging.WARNING, logger="netsuite.rest_api"):
         await rest_api.suiteql(q="SELECT order_by_id FROM custom_table")
     assert not any("ORDER BY" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# 2026.1 REST web services operations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_attach_posts_to_attach_endpoint_with_empty_body(dummy_config):
+    rest_api = NetSuiteRestApi(dummy_config)
+    rest_api._request = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    result = await rest_api.attach("customer", "660", "contact", "106")
+    assert result is None
+    args, kwargs = rest_api._request.await_args
+    assert args == (
+        "POST",
+        "/record/v1/customer/660/!attach/contact/106",
+    )
+    # Body defaults to an empty object when no role is given.
+    assert kwargs["json"] == {}
+
+
+@pytest.mark.asyncio
+async def test_attach_includes_role_when_provided(dummy_config):
+    rest_api = NetSuiteRestApi(dummy_config)
+    rest_api._request = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    await rest_api.attach("customer", "660", "contact", "106", role={"id": "-10"})
+    _, kwargs = rest_api._request.await_args
+    assert kwargs["json"] == {"role": {"id": "-10"}}
+
+
+@pytest.mark.asyncio
+async def test_attach_supports_external_ids(dummy_config):
+    rest_api = NetSuiteRestApi(dummy_config)
+    rest_api._request = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    await rest_api.attach("customer", "eid:JOHN_DOE42", "contact", "eid:user1")
+    args, _ = rest_api._request.await_args
+    assert args[1] == ("/record/v1/customer/eid:JOHN_DOE42/!attach/contact/eid:user1")
+
+
+@pytest.mark.asyncio
+async def test_detach_posts_to_detach_endpoint_without_body(dummy_config):
+    rest_api = NetSuiteRestApi(dummy_config)
+    rest_api._request = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    await rest_api.detach("opportunity", "379", "file", "398")
+    args, kwargs = rest_api._request.await_args
+    assert args == (
+        "POST",
+        "/record/v1/opportunity/379/!detach/file/398",
+    )
+    # Detach sends no body at all.
+    assert "json" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_create_form_posts_transform_with_accept_header(dummy_config):
+    rest_api = NetSuiteRestApi(dummy_config)
+    rest_api._request = AsyncMock(return_value={"id": "1"})  # type: ignore[method-assign]
+    await rest_api.create_form("salesOrder", "1", "itemFulfillment")
+    args, kwargs = rest_api._request.await_args
+    assert args == (
+        "POST",
+        "/record/v1/salesOrder/1/!transform/itemFulfillment",
+    )
+    assert (
+        kwargs["headers"]["Accept"]
+        == "application/vnd.oracle.resource+json; type=create-form"
+    )
+    assert kwargs["json"] == {}
+
+
+@pytest.mark.asyncio
+async def test_select_options_uses_post_for_new_instance(dummy_config):
+    rest_api = NetSuiteRestApi(dummy_config)
+    rest_api._request = AsyncMock(return_value={})  # type: ignore[method-assign]
+    await rest_api.select_options("customer", "entitystatus")
+    args, kwargs = rest_api._request.await_args
+    assert args == ("POST", "/record/v1/customer")
+    assert kwargs["params"]["fields"] == "entitystatus"
+    assert (
+        kwargs["headers"]["Accept"]
+        == "application/vnd.oracle.resource+json; type=select-options"
+    )
+
+
+@pytest.mark.asyncio
+async def test_select_options_uses_patch_for_existing_instance(dummy_config):
+    rest_api = NetSuiteRestApi(dummy_config)
+    rest_api._request = AsyncMock(return_value={})  # type: ignore[method-assign]
+    await rest_api.select_options(
+        "advInterCompanyJournalEntry",
+        ["line.dueToFromSubsidiary", "subsidiary"],
+        record_id="5",
+        body={"subsidiary": {"id": 1}},
+    )
+    args, kwargs = rest_api._request.await_args
+    assert args == ("PATCH", "/record/v1/advInterCompanyJournalEntry/5")
+    # Multiple fields are comma-joined; dependent values ride in the body.
+    assert kwargs["params"]["fields"] == "line.dueToFromSubsidiary,subsidiary"
+    assert kwargs["json"] == {"subsidiary": {"id": 1}}
+
+
+@pytest.mark.asyncio
+async def test_batch_sets_async_headers_and_returns_job_location(dummy_config):
+    rest_api = NetSuiteRestApi(dummy_config)
+    job_url = "https://x.suitetalk.api.netsuite.com/services/rest/async/v1/job/42"
+    fake_resp = SimpleNamespace(
+        status_code=202,
+        text="",
+        headers={"Location": job_url},
+    )
+    rest_api._request_impl = AsyncMock(return_value=fake_resp)  # type: ignore[method-assign]
+    result = await rest_api.batch(
+        "salesOrder",
+        [{"name": "item 1"}, {"name": "item 2"}],
+        idempotency_key="abc-123",
+    )
+    args, kwargs = rest_api._request_impl.await_args
+    assert args == ("POST", "/record/v1/salesOrder")
+    assert kwargs["headers"]["Prefer"] == "respond-async"
+    assert (
+        kwargs["headers"]["Content-Type"]
+        == "application/vnd.oracle.resource+json; type=collection"
+    )
+    assert kwargs["headers"]["X-NetSuite-idempotency-key"] == "abc-123"
+    assert kwargs["json"] == {"items": [{"name": "item 1"}, {"name": "item 2"}]}
+    assert result == {"status_code": 202, "location": job_url, "body": None}
+
+
+@pytest.mark.asyncio
+async def test_batch_rejects_non_write_methods(dummy_config):
+    rest_api = NetSuiteRestApi(dummy_config)
+    rest_api._request_impl = AsyncMock()  # type: ignore[method-assign]
+    with pytest.raises(ValueError, match="batch\\(\\) method must be"):
+        await rest_api.batch("salesOrder", [], method="GET")
+    rest_api._request_impl.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_batch_raises_on_error_status(dummy_config):
+    rest_api = NetSuiteRestApi(dummy_config)
+    fake_resp = SimpleNamespace(status_code=400, text="bad request", headers={})
+    rest_api._request_impl = AsyncMock(return_value=fake_resp)  # type: ignore[method-assign]
+    with pytest.raises(NetsuiteAPIRequestError):
+        await rest_api.batch("salesOrder", [{"name": "x"}], method="PATCH")


### PR DESCRIPTION
Add convenience wrappers on NetSuiteRestApi for the four REST operations introduced in the NetSuite 2026.1 release, mirroring the existing suiteql/jsonschema/openapi helpers. All were already reachable via the generic get/post/patch methods; these absorb the operation-specific URL shapes and custom media-type headers:

- attach() / detach(): POST /record/v1/{t}/{id}/!attach|!detach/{tt}/{tid}; optional contact "role" body; returns None on the 204 response. Internal and eid: external IDs both work.
- create_form(): POST .../!transform/{tt} with the "Accept: application/vnd.oracle.resource+json; type=create-form" header, returning a record prepopulated from a related record.
- select_options(): POST (new instance) or PATCH (existing, via record_id) with the type=select-options Accept header and a comma-joined "fields" param; dependent field values ride in the body.
- batch(): async homogeneous add/update/upsert (max 100) with the "Prefer: respond-async" + type=collection headers. Talks to _request_impl directly to surface the async job's Location header, which the JSON-only _request helper discards.

Covered by unit tests asserting method, URL, headers, params and body for each operation.