### PR TITLE
fix(oauth2): sign with the configured algorithm so PS256 (the default…

### DIFF
--- a/netsuite/oauth2.py
+++ b/netsuite/oauth2.py
@@ -174,7 +174,11 @@ def build_client_assertion(
         "exp": expires_at,
     }
     key = _load_signing_key(private_key_pem, algorithm)
-    return jwt.encode(header, claims, key)
+    # joserfc's default registry only permits its "recommended" algorithms
+    # (RS256/ES256/...), and rejects PS256 — which is this module's default,
+    # and NetSuite's recommended assertion algorithm. Explicitly whitelist the
+    # chosen algorithm so every entry in SUPPORTED_ALGORITHMS actually signs.
+    return jwt.encode(header, claims, key, algorithms=[algorithm])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_oauth2.py
+++ b/tests/test_oauth2.py
@@ -13,6 +13,7 @@ from joserfc import jwt as jose_jwt
 from joserfc.jwk import RSAKey
 
 from netsuite.oauth2 import (
+    DEFAULT_ALGORITHM,
     DEFAULT_SCOPES,
     JWT_BEARER_ASSERTION_TYPE,
     OAuth2BearerAuth,
@@ -124,6 +125,25 @@ def test_client_assertion_carries_required_claims(rsa_private_key_pem, rsa_publi
     assert claims["iat"] == 1_700_000_000
     # NetSuite caps `exp` at iat + 3600.
     assert claims["exp"] == 1_700_000_000 + 3600
+
+
+def test_client_assertion_signs_with_default_algorithm(
+    rsa_private_key_pem, rsa_public_jwk
+):
+    """Regression: the module default is PS256, which joserfc's default
+    registry rejects unless the algorithm is explicitly whitelisted in
+    `jwt.encode`. Every other assertion test pins RS256, so the default
+    path went uncovered. Build with no `algorithm=` and confirm it signs."""
+    assert DEFAULT_ALGORITHM == "PS256"
+    assertion = build_client_assertion(
+        "123456_SB1",
+        client_id="my-app",
+        certificate_id="cert-kid-42",
+        private_key_pem=rsa_private_key_pem,
+    )
+    decoded = jose_jwt.decode(assertion, rsa_public_jwk, algorithms=[DEFAULT_ALGORITHM])
+    assert decoded.header["alg"] == "PS256"
+    assert decoded.header["kid"] == "cert-kid-42"
 
 
 def test_client_assertion_clamps_ttl_to_one_hour(rsa_private_key_pem, rsa_public_jwk):


### PR DESCRIPTION
…) works

build_client_assertion called jwt.encode(header, claims, key) without an algorithms argument. joserfc's default registry only permits its "recommended" algorithms (RS256/ES256/...) and raises UnsupportedAlgorithmError for PS256 -- which is this module's DEFAULT_ALGORITHM and NetSuite's recommended assertion algorithm. So the default machine-to-machine flow failed at signing time; only callers explicitly passing algorithm="RS256" worked (ES384/ES512 were affected too).

Whitelist the chosen algorithm in jwt.encode so every entry in SUPPORTED_ALGORITHMS actually signs. Confirmed against a live NetSuite sandbox: a PS256 assertion now signs and the M2M token endpoint accepts it.

Every existing assertion test pinned algorithm="RS256", so the default PS256 path was never exercised. Add a regression test that builds an assertion with no algorithm= and asserts it signs as PS256.