### PR TITLE
feat(rest): add create_record() that returns the new record's ID

### DIFF
--- a/netsuite/rest_api.py
+++ b/netsuite/rest_api.py
@@ -449,6 +449,55 @@ class NetSuiteRestApi(rest_api_base.RestApiBase):
             "body": body,
         }
 
+    async def create_record(
+        self,
+        record_type: str,
+        record_data: Dict[str, Any],
+        **request_kw,
+    ) -> Union[int, str, None]:
+        """
+        Create a record and return the internal ID NetSuite assigns to it.
+
+        POSTs `record_data` to `/record/v1/{record_type}`. NetSuite answers a
+        successful create with HTTP 204 No Content and a `Location` header
+        pointing at the new record; this parses the trailing ID segment and
+        returns it as an `int` when numeric, or the raw string for external
+        IDs (`eid:...`). Returns `None` if NetSuite omits the `Location`
+        header.
+
+        Talks to the lower-level request layer directly (like `batch`)
+        because the new record's ID is only exposed in the `Location`
+        response header, which the JSON helper `_request` discards.
+
+        https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_1545141395.html
+        """
+        resp = await self._request_impl(
+            "POST",
+            f"/record/v1/{record_type}",
+            json=record_data,
+            **request_kw,
+        )
+        if resp.status_code < 200 or resp.status_code > 299:
+            raise NetsuiteAPIRequestError(resp.status_code, resp.text)
+        return self._parse_id_from_location(resp.headers.get("Location"))
+
+    @staticmethod
+    def _parse_id_from_location(location: Optional[str]) -> Union[int, str, None]:
+        """Extract the record ID (last path segment) from a `Location` URL,
+        ignoring any query string or fragment and tolerating a trailing
+        slash. Returns an `int` for numeric IDs, the raw string otherwise,
+        or `None` when no usable segment is present."""
+        if not location:
+            return None
+        path = location.split("?", 1)[0].split("#", 1)[0].rstrip("/")
+        record_id = path.rsplit("/", 1)[-1]
+        if not record_id:
+            return None
+        try:
+            return int(record_id)
+        except ValueError:
+            return record_id
+
     def _make_hostname(self):
         return f"{self._config.account_slugified}.suitetalk.api.netsuite.com"
 

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -2,6 +2,7 @@ import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+import httpx
 import pytest
 
 from netsuite import NetSuiteRestApi
@@ -276,3 +277,96 @@ async def test_batch_raises_on_error_status(dummy_config):
     rest_api._request_impl = AsyncMock(return_value=fake_resp)  # type: ignore[method-assign]
     with pytest.raises(NetsuiteAPIRequestError):
         await rest_api.batch("salesOrder", [{"name": "x"}], method="PATCH")
+
+
+# ---------------------------------------------------------------------------
+# create_record — POST a record and return the new ID from the Location header
+# ---------------------------------------------------------------------------
+
+
+def _created_response(location, *, status_code=204):
+    # NetSuite answers a create with 204 No Content and a Location header
+    # pointing at the new record. httpx.Headers is case-insensitive, which
+    # is what the real response uses.
+    return SimpleNamespace(
+        status_code=status_code,
+        text="",
+        headers=httpx.Headers({"Location": location} if location else {}),
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_record_posts_data_to_collection_endpoint(dummy_config):
+    rest_api = NetSuiteRestApi(dummy_config)
+    loc = "https://x.suitetalk.api.netsuite.com/services/rest/record/v1/customer/647"
+    rest_api._request_impl = AsyncMock(  # type: ignore[method-assign]
+        return_value=_created_response(loc)
+    )
+    data = {"companyName": "Acme", "subsidiary": {"id": "1"}}
+    await rest_api.create_record("customer", data)
+    args, kwargs = rest_api._request_impl.await_args
+    assert args == ("POST", "/record/v1/customer")
+    assert kwargs["json"] == data
+
+
+@pytest.mark.asyncio
+async def test_create_record_returns_int_for_numeric_id(dummy_config):
+    rest_api = NetSuiteRestApi(dummy_config)
+    loc = "https://x.suitetalk.api.netsuite.com/services/rest/record/v1/customer/647"
+    rest_api._request_impl = AsyncMock(  # type: ignore[method-assign]
+        return_value=_created_response(loc)
+    )
+    result = await rest_api.create_record("customer", {})
+    assert result == 647
+    assert isinstance(result, int)
+
+
+@pytest.mark.asyncio
+async def test_create_record_returns_str_for_external_id(dummy_config):
+    rest_api = NetSuiteRestApi(dummy_config)
+    loc = (
+        "https://x.suitetalk.api.netsuite.com/services/rest/record/v1/"
+        "customer/eid:ACME_42"
+    )
+    rest_api._request_impl = AsyncMock(  # type: ignore[method-assign]
+        return_value=_created_response(loc)
+    )
+    result = await rest_api.create_record("customer", {})
+    assert result == "eid:ACME_42"
+
+
+@pytest.mark.asyncio
+async def test_create_record_ignores_query_and_trailing_slash(dummy_config):
+    """Regression vs the original `/([^/]+)$` regex, which would return the
+    querystring or an empty segment. The ID is the last real path segment."""
+    rest_api = NetSuiteRestApi(dummy_config)
+    loc = (
+        "https://x.suitetalk.api.netsuite.com/services/rest/record/v1/"
+        "salesOrder/980/?expandSubResources=true"
+    )
+    rest_api._request_impl = AsyncMock(  # type: ignore[method-assign]
+        return_value=_created_response(loc)
+    )
+    result = await rest_api.create_record("salesOrder", {})
+    assert result == 980
+
+
+@pytest.mark.asyncio
+async def test_create_record_returns_none_without_location_header(dummy_config):
+    rest_api = NetSuiteRestApi(dummy_config)
+    rest_api._request_impl = AsyncMock(  # type: ignore[method-assign]
+        return_value=_created_response(None)
+    )
+    result = await rest_api.create_record("customer", {})
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_create_record_raises_on_error_status(dummy_config):
+    rest_api = NetSuiteRestApi(dummy_config)
+    fake_resp = SimpleNamespace(status_code=400, text="bad", headers=httpx.Headers())
+    rest_api._request_impl = AsyncMock(  # type: ignore[method-assign]
+        return_value=fake_resp
+    )
+    with pytest.raises(NetsuiteAPIRequestError):
+        await rest_api.create_record("customer", {"bad": "data"})


### PR DESCRIPTION
NetSuite answers a REST create with 204 No Content and a Location header pointing at the new record, so the JSON-only _request helper (which returns None on 204) gives callers no way to learn the assigned ID.

Add create_record(record_type, record_data): it POSTs to /record/v1/{record_type} via _request_impl directly (the same pattern batch() uses to reach the Location header), then returns the ID parsed from that header -- an int for numeric IDs, the raw string for external IDs (eid:...), or None when no Location is present.

This is a scoped reimplementation of the idea in PR #121. Unlike that PR it does not mutate the generic _request to special-case every 204 POST (which would silently change the return type of all POSTs), and the ID parser ignores query strings/fragments and tolerates a trailing slash rather than using a bare /([^/]+)$ regex that would capture a querystring.

Tested: collection-endpoint POST + body, numeric id -> int, external id ->
str, query/trailing-slash handling, missing-header -> None, error status raises.